### PR TITLE
Improved wiki category tool UI + bug fixes

### DIFF
--- a/app/frontend/components/category-tree.component.tsx
+++ b/app/frontend/components/category-tree.component.tsx
@@ -105,7 +105,7 @@ export default function CategoryTree({ treeData }: { treeData: CategoryNode }) {
   const handleNodeSelect = async (selectProps: ITreeViewOnNodeSelectProps) => {
     if (
       selectProps.isSelected &&
-      !selectProps.isBranch &&
+      !selectProps.element.isBranch &&
       !nodesAlreadyLoaded.includes(selectProps.element) &&
       selectProps.element?.parent === 1 // This is the hardcoded id for the top-level parent node
     ) {
@@ -165,12 +165,14 @@ export default function CategoryTree({ treeData }: { treeData: CategoryNode }) {
             isBranch,
             isExpanded,
             isSelected,
+            isDisabled,
             isHalfSelected,
             getNodeProps,
             level,
             handleSelect,
             handleExpand,
           }) => {
+            isDisabled = !!(element.isBranch && element.children.length === 0);
             const branchNode = (
               isExpanded: boolean,
               element: INode<IFlatMetadata>
@@ -184,19 +186,34 @@ export default function CategoryTree({ treeData }: { treeData: CategoryNode }) {
             return (
               <div
                 {...getNodeProps({ onClick: handleExpand })}
-                style={{ marginLeft: 40 * (level - 1) }}
+                style={{
+                  marginLeft: 40 * (level - 1),
+                }}
               >
                 {isBranch && branchNode(isExpanded, element)}
                 <CheckBoxIcon
                   onClick={(e) => {
-                    handleSelect(e);
+                    if (!isDisabled) {
+                      handleSelect(e);
+                    }
                     e.stopPropagation();
                   }}
                   variant={
-                    isHalfSelected ? "some" : isSelected ? "all" : "none"
+                    isDisabled
+                      ? "disabled"
+                      : isHalfSelected
+                      ? "some"
+                      : isSelected
+                      ? "all"
+                      : "none"
                   }
                 />
-                <span className="name">{element.name}</span>
+                <span
+                  className="name"
+                  style={{ opacity: isDisabled ? 0.5 : 1 }}
+                >
+                  {element.name}
+                </span>
               </div>
             );
           }}
@@ -216,6 +233,14 @@ const ArrowIcon: FC<ArrowIconProps> = ({ isOpen, className = "" }) => {
 
 const CheckBoxIcon: FC<CheckBoxIconProps> = ({ variant, onClick }) => {
   switch (variant) {
+    case "disabled":
+      return (
+        <FaSquare
+          onClick={onClick}
+          className="checkbox-icon"
+          style={{ opacity: 0.5 }}
+        />
+      );
     case "all":
       return <FaCheckSquare onClick={onClick} className="checkbox-icon" />;
     case "none":
@@ -228,7 +253,7 @@ const CheckBoxIcon: FC<CheckBoxIconProps> = ({ variant, onClick }) => {
 };
 
 type CheckBoxIconProps = {
-  variant: "all" | "none" | "some";
+  variant: "all" | "none" | "some" | "disabled";
   onClick: (event: React.MouseEvent<SVGElement, MouseEvent>) => void;
 };
 

--- a/app/frontend/components/category-tree.component.tsx
+++ b/app/frontend/components/category-tree.component.tsx
@@ -157,7 +157,6 @@ export default function CategoryTree({ treeData }: { treeData: CategoryNode }) {
           aria-label="Checkbox tree"
           multiSelect
           propagateSelect
-          propagateSelectUpwards
           togglableSelect
           onLoadData={wrappedOnLoadData}
           onSelect={handleNodeSelect}

--- a/app/frontend/components/selected-nodes-display.component.tsx
+++ b/app/frontend/components/selected-nodes-display.component.tsx
@@ -11,15 +11,22 @@ export default function SelectedNodesDisplay({
   selectedNodes: Map<NodeId, INode<IFlatMetadata>>;
 }) {
   const [articlesCount, setArticlesCount] = useState<number>(0);
+  const [categoriesCount, setCategoriesCount] = useState<number>(0);
 
   useEffect(() => {
-    let count = 0;
+    let totalNodeArticlesCount = 0;
+    let totalNodeCategoriesCount = 0;
     selectedNodes.forEach((node) => {
       if (node.metadata) {
-        count += Object.keys(node.metadata).length;
+        const nodeArticlesCount = Object.keys(node.metadata).length;
+        if (nodeArticlesCount > 0) {
+          totalNodeCategoriesCount += 1;
+        }
+        totalNodeArticlesCount += nodeArticlesCount;
       }
     });
-    setArticlesCount(count);
+    setArticlesCount(totalNodeArticlesCount);
+    setCategoriesCount(totalNodeCategoriesCount);
   }, [selectedNodes]);
   return (
     <div className="SelectedNodes Box">
@@ -28,7 +35,7 @@ export default function SelectedNodesDisplay({
         csvConvert={convertCategoryArticlesToCSV}
       />
       <h3 className="u-mt1">Selected Articles</h3>
-      {articlesCount} articles from {selectedNodes.size} categories
+      {articlesCount} articles from {categoriesCount} categories
       <ul>
         {[...selectedNodes.values()].map((node) => {
           return node.metadata

--- a/app/frontend/components/wikipedia-category-page.component.tsx
+++ b/app/frontend/components/wikipedia-category-page.component.tsx
@@ -20,7 +20,11 @@ export default function WikipediaCategoryPage() {
     event.preventDefault();
     setIsLoading(true);
     try {
-      const categoryName = categoryURL.split("/").slice(-1)[0];
+      let categoryName;
+      if (categoryURL.startsWith("Category:")) {
+        categoryName = categoryURL;
+      }
+      categoryName = categoryURL.split("/").slice(-1)[0];
       const fetchedSubcatsAndPages = await fetchSubcatsAndPages(categoryName);
       if (!fetchedSubcatsAndPages) {
         throw new Error("Invalid Response (possibly null)");


### PR DESCRIPTION
This PR does the following:
- Fixes bug that caused category count to be inaccurate
- Adds support for category name as input instead of category URL
- Adds a "disabled" state for category tree nodes that haven't had their data fetched yet

**Screenshot**
![image](https://github.com/WikiEducationFoundation/impact-visualizer/assets/39999898/4177977d-a796-4116-bf95-9324f359f23b)
