### PR TITLE
Added Multilanguage support for category tool

### DIFF
--- a/app/frontend/components/category-tree.component.tsx
+++ b/app/frontend/components/category-tree.component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { useState } from "react";
 import TreeView, {
   INode,
   ITreeViewOnExpandProps,
@@ -7,8 +7,6 @@ import TreeView, {
   NodeId,
   flattenTree,
 } from "react-accessible-treeview";
-import { FaSquare, FaCheckSquare, FaMinusSquare } from "react-icons/fa";
-import { IoMdArrowDropright } from "react-icons/io";
 import { AiOutlineLoading } from "react-icons/ai";
 import { CategoryNode } from "../types/search-tool.type";
 import { IFlatMetadata } from "react-accessible-treeview/dist/TreeView/utils";
@@ -19,7 +17,13 @@ import toast from "react-hot-toast";
 import { BsExclamationCircleFill } from "react-icons/bs";
 import { ArrowIcon, CheckBoxIcon } from "./tree-icons.component";
 
-export default function CategoryTree({ treeData }: { treeData: CategoryNode }) {
+export default function CategoryTree({
+  treeData,
+  languageCode,
+}: {
+  treeData: CategoryNode;
+  languageCode: string;
+}) {
   const [categoryTree, setCategoryTree] = useState<INode<IFlatMetadata>[]>(
     flattenTree(treeData)
   );
@@ -62,7 +66,11 @@ export default function CategoryTree({ treeData }: { treeData: CategoryNode }) {
     if (depth > DEPTH_LIMIT && node.isBranch) {
       return [];
     }
-    const fetchedSubcatsAndPages = await fetchSubcatsAndPages(node.id, true);
+    const fetchedSubcatsAndPages = await fetchSubcatsAndPages(
+      node.id,
+      languageCode,
+      true
+    );
     if (!fetchedSubcatsAndPages) {
       toast.error("Failed to fetch subcategories");
       return [];
@@ -114,6 +122,7 @@ export default function CategoryTree({ treeData }: { treeData: CategoryNode }) {
     ) {
       const fetchedSubcatsAndPages = await fetchSubcatsAndPages(
         selectProps.element.id,
+        languageCode,
         true
       );
       if (!fetchedSubcatsAndPages) {

--- a/app/frontend/components/selected-nodes-display.component.tsx
+++ b/app/frontend/components/selected-nodes-display.component.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
 import { INode, NodeId } from "react-accessible-treeview";
 import { IFlatMetadata } from "react-accessible-treeview/dist/TreeView/utils";
 import CSVButton from "./CSV-button.component";
-import { convertCategoryArticlesToCSV } from "../utils/search-utils";
+import {
+  convertCategoryArticlesToCSV,
+  removeDuplicateArticles,
+} from "../utils/search-utils";
 import React from "react";
 
 export default function SelectedNodesDisplay({
@@ -10,39 +12,39 @@ export default function SelectedNodesDisplay({
 }: {
   selectedNodes: Map<NodeId, INode<IFlatMetadata>>;
 }) {
-  const [articlesCount, setArticlesCount] = useState<number>(0);
-  const [categoriesCount, setCategoriesCount] = useState<number>(0);
+  let categoriesCount = 0;
+  const selectedCategories = [...selectedNodes.values()].map((node) => {
+    return node.metadata
+      ? Object.entries(node.metadata).map(([key, value]) => {
+          return { [key]: String(value) };
+        })
+      : [];
+  });
 
-  useEffect(() => {
-    let totalNodeArticlesCount = 0;
-    let totalNodeCategoriesCount = 0;
-    selectedNodes.forEach((node) => {
-      if (node.metadata) {
-        const nodeArticlesCount = Object.keys(node.metadata).length;
-        if (nodeArticlesCount > 0) {
-          totalNodeCategoriesCount += 1;
-        }
-        totalNodeArticlesCount += nodeArticlesCount;
-      }
+  let selectedArticles = selectedCategories
+    .reduce((acc, node) => {
+      acc = [...acc, ...node];
+      categoriesCount += 1;
+
+      return acc;
+    }, [])
+    .map((article) => {
+      const [id] = Object.keys(article);
+      return { articleId: id, articleTitle: article[id] };
     });
-    setArticlesCount(totalNodeArticlesCount);
-    setCategoriesCount(totalNodeCategoriesCount);
-  }, [selectedNodes]);
+  selectedArticles = removeDuplicateArticles(selectedArticles);
+
   return (
     <div className="SelectedNodes Box">
       <CSVButton
-        articles={selectedNodes.values()}
+        articles={selectedArticles.map((article) => article.articleTitle)}
         csvConvert={convertCategoryArticlesToCSV}
       />
       <h3 className="u-mt1">Selected Articles</h3>
-      {articlesCount} articles from {categoriesCount} categories
+      {selectedArticles.length} articles from {categoriesCount} categories
       <ul>
-        {[...selectedNodes.values()].map((node) => {
-          return node.metadata
-            ? Object.entries(node.metadata).map(([key, value]) => {
-                return <li key={key}>{`${value}`}</li>;
-              })
-            : null;
+        {selectedArticles.map((article) => {
+          return <li key={article.articleId}>{`${article.articleTitle}`}</li>;
         })}
       </ul>
     </div>

--- a/app/frontend/components/wikipedia-category-page.component.tsx
+++ b/app/frontend/components/wikipedia-category-page.component.tsx
@@ -11,24 +11,25 @@ import { CheckBoxIcon } from "./tree-icons.component";
 
 export default function WikipediaCategoryPage() {
   const [categoryURL, setCategoryURL] = useState<string>("");
+  const [languageCode, setLanguageCode] = useState<string>("");
+
   const [SubcatsData, setSubcatsData] = useState<CategoryNode>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setCategoryURL(event.target.value);
-  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsLoading(true);
     try {
-      let categoryName = categoryURL;
+      let categoryName = decodeURI(categoryURL);
       if (categoryURL.startsWith("https://")) {
-        categoryName = categoryURL.split("/").slice(-1)[0];
+        categoryName = decodeURI(categoryURL.split("/").slice(-1)[0]);
       } else if (!categoryURL.toUpperCase().startsWith("CATEGORY:")) {
         categoryName = "Category:" + categoryURL;
       }
-      const fetchedSubcatsAndPages = await fetchSubcatsAndPages(categoryName);
+      const fetchedSubcatsAndPages = await fetchSubcatsAndPages(
+        categoryName,
+        languageCode
+      );
       if (!fetchedSubcatsAndPages) {
         throw new Error("Invalid Response (possibly null)");
       }
@@ -83,13 +84,22 @@ export default function WikipediaCategoryPage() {
         </div>
         <br />
         <h3>Enter a category URL, select and browse subcategories</h3>
-        <input
-          type="text"
-          value={categoryURL}
-          onChange={handleChange}
-          placeholder="Enter a Category URL"
-          required
-        />
+        <div>
+          <input
+            type="text"
+            value={categoryURL}
+            onChange={(event) => setCategoryURL(event.target.value)}
+            placeholder="Enter a Category URL"
+            required
+          />
+          <input
+            type="text"
+            value={languageCode}
+            onChange={(event) => setLanguageCode(event.target.value)}
+            placeholder="Language Code"
+            required
+          />
+        </div>
         <button type="submit" className="Button u-mt1" disabled={isLoading}>
           Run Query
         </button>
@@ -99,7 +109,7 @@ export default function WikipediaCategoryPage() {
           <LoadingOval visible={isLoading} height="100" width="100" />
         </div>
       ) : SubcatsData ? (
-        <CategoryTree treeData={SubcatsData} />
+        <CategoryTree treeData={SubcatsData} languageCode={languageCode} />
       ) : (
         ""
       )}

--- a/app/frontend/services/articles.service.tsx
+++ b/app/frontend/services/articles.service.tsx
@@ -2,10 +2,12 @@ import { MediaWikiResponse } from "../types/search-tool.type";
 
 async function fetchSubcatsAndPages(
   categoryIdentifier: string | number,
+  languageCode: string,
   usePageID: boolean = false
 ): Promise<MediaWikiResponse | null> {
   let queriedSubcatsJSON: MediaWikiResponse | null = null;
   try {
+    let baseURL = `https://${languageCode}.wikipedia.org/w/api.php`;
     let identifier: string = "";
     if (usePageID) {
       identifier = `gcmpageid=${categoryIdentifier}`;
@@ -13,9 +15,7 @@ async function fetchSubcatsAndPages(
       identifier = `gcmtitle=${categoryIdentifier}`;
     }
     const urlParams: string = `action=query&generator=categorymembers&gcmlimit=500&prop=categoryinfo&${identifier}&format=json&origin=*`;
-    const response = await fetch(
-      `https://en.wikipedia.org/w/api.php?${urlParams}`
-    );
+    const response = await fetch(`${baseURL}?${urlParams}`);
 
     if (!response.ok) {
       throw new Error("Network response was not ok.");
@@ -25,7 +25,7 @@ async function fetchSubcatsAndPages(
 
     while (queriedSubcatsJSON?.continue?.continue) {
       const continueResponse = await fetch(
-        `https://en.wikipedia.org/w/api.php?gcmcontinue=${queriedSubcatsJSON?.continue?.gcmcontinue}&${urlParams}`
+        `${baseURL}?gcmcontinue=${queriedSubcatsJSON?.continue?.gcmcontinue}&${urlParams}`
       );
       const continueSubcatsJSON: MediaWikiResponse =
         await continueResponse.json();

--- a/app/frontend/styles/modules/category-tree.postcss
+++ b/app/frontend/styles/modules/category-tree.postcss
@@ -119,3 +119,14 @@
   }
   overflow-y: auto;
 }
+.CategorySearch {
+  display: flex;
+  gap: 5px;
+  input:first-of-type {
+    flex: 1;
+  }
+
+  input:nth-of-type(2) {
+    flex: 11;
+  }
+}

--- a/app/frontend/utils/search-utils.tsx
+++ b/app/frontend/utils/search-utils.tsx
@@ -6,10 +6,9 @@ import {
 } from "../types/search-tool.type";
 import { IFlatMetadata } from "react-accessible-treeview/dist/TreeView/utils";
 
+/* slice out category prefix */
 const removeCategoryPrefix = (categoryString: string): string => {
-  return categoryString.substring(
-    categoryString.indexOf(":") + 1
-  ); /* slice out category prefix */
+  return categoryString.substring(categoryString.indexOf(":") + 1);
 };
 
 function buildWikidataQuery(
@@ -64,15 +63,10 @@ function convertSPARQLArticlesToCSV(
   return csvContent;
 }
 
-function convertCategoryArticlesToCSV(
-  categories: IterableIterator<INode<IFlatMetadata>>
-): string {
+function convertCategoryArticlesToCSV(articles: string[]): string {
   let csvContent = "data:text/csv;charset=utf-8,";
-  for (const category of categories) {
-    const metadata = category.metadata || {};
-    for (const article of Object.values(metadata)) {
-      csvContent += `"${article}"\n`;
-    }
+  for (const article of articles) {
+    csvContent += `"${article}"\n`;
   }
 
   return csvContent;
@@ -179,6 +173,23 @@ const convertResponseToTree = (
   return subcats;
 };
 
+const removeDuplicateArticles = (
+  selectedArticles: {
+    articleId: string;
+    articleTitle: string;
+  }[]
+) => {
+  const uniqueIds = new Set();
+  return selectedArticles.filter((article) => {
+    if (uniqueIds.has(article.articleId)) {
+      return false;
+    } else {
+      uniqueIds.add(article.articleId);
+      return true;
+    }
+  });
+};
+
 export {
   buildWikidataQuery,
   convertSPARQLArticlesToCSV,
@@ -186,4 +197,6 @@ export {
   downloadAsCSV,
   convertInitialResponseToTree,
   convertResponseToTree,
+  removeCategoryPrefix,
+  removeDuplicateArticles,
 };

--- a/app/frontend/utils/search-utils.tsx
+++ b/app/frontend/utils/search-utils.tsx
@@ -6,6 +6,12 @@ import {
 } from "../types/search-tool.type";
 import { IFlatMetadata } from "react-accessible-treeview/dist/TreeView/utils";
 
+const removeCategoryPrefix = (categoryString: string): string => {
+  return categoryString.substring(
+    categoryString.indexOf(":") + 1
+  ); /* slice out category prefix */
+};
+
 function buildWikidataQuery(
   occupationIDs: string[],
   genderID: string,
@@ -90,7 +96,7 @@ const convertInitialResponseToTree = (
   const pages = response.query.pages;
 
   const parentNode: CategoryNode = {
-    name: parentName.slice(9).replaceAll("_", " "),
+    name: removeCategoryPrefix(parentName).replaceAll("_", " "),
     isBranch: true,
     id: elementId + 1,
     metadata: {},
@@ -118,9 +124,9 @@ const convertInitialResponseToTree = (
       if (isDuplicateNode) {
         continue;
       }
-      const categoryName: string = `${
-        value.title.slice(9) /* slice out "category:" prefix */
-      } (${value.categoryinfo.subcats} C, ${value.categoryinfo.pages} P)`;
+      const categoryName: string = `${removeCategoryPrefix(value.title)} (${
+        value.categoryinfo.subcats
+      } C, ${value.categoryinfo.pages} P)`;
 
       parentNode.children?.push({
         name: categoryName,
@@ -153,9 +159,9 @@ const convertResponseToTree = (
   const subcats: INode<IFlatMetadata>[] = [];
   for (const [, value] of Object.entries(pages)) {
     if (value.categoryinfo) {
-      const categoryName: string = `${
-        value.title.slice(9) /* slice out "category:" prefix */
-      } (${value.categoryinfo.subcats} C, ${value.categoryinfo.pages} P)`;
+      const categoryName: string = `${removeCategoryPrefix(value.title)} (${
+        value.categoryinfo.subcats
+      } C, ${value.categoryinfo.pages} P)`;
 
       subcats.push({
         name: categoryName,


### PR DESCRIPTION
This PR adds multilanguage support for the wikipedia category tool. Users can now enter a language code in conjunction with the category name to get categories in the specified wikilanguage.

**Video**

https://github.com/user-attachments/assets/b1c49fc9-891f-481a-83a3-4c814a8a3e75

