### PR TITLE
Added the ability to fetch labels from wikidata items even with no corresponding wikipedia articles

### DIFF
--- a/app/frontend/components/articles-table.component.tsx
+++ b/app/frontend/components/articles-table.component.tsx
@@ -26,7 +26,11 @@ export default function ArticlesTable({
           {articles.map((item, index) => (
             <tr key={index}>
               <td>
-                <a href={item.article.value}>{item.personLabel.value}</a>
+                {item.article ? (
+                  <a href={item.article.value}>{item.personLabel.value}</a>
+                ) : (
+                  <a href={item.person.value}>{item.personLabel.value}</a>
+                )}{" "}
               </td>
             </tr>
           ))}

--- a/app/frontend/components/query-builder.component.tsx
+++ b/app/frontend/components/query-builder.component.tsx
@@ -32,6 +32,8 @@ export default function QueryBuilder() {
   const [languageCode, setLanguageCode] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
+  const [requireWikiArticle, setRequireWikiArticle] = useState<boolean>(false);
+
   const handleAddQueryItem = () => {
     if (queryItemsData.length < 5) {
       setQueryItemsData([
@@ -89,7 +91,8 @@ export default function QueryBuilder() {
       occupations.map((occupation) => occupation.qValue.id),
       gender.length > 0 ? gender[0].qValue.id : "",
       ethnicity.length > 0 ? ethnicity[0].qValue.id : "",
-      languageCode
+      languageCode,
+      { requireWikipediaArticle: requireWikiArticle }
     );
     try {
       const response = await fetch(
@@ -119,6 +122,7 @@ export default function QueryBuilder() {
 
     return queriedArticlesJSON;
   }
+
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
@@ -155,6 +159,16 @@ export default function QueryBuilder() {
             +
           </button>
         )}
+        <div className="u-mt1">
+          <label>
+            <input
+              type="checkbox"
+              checked={requireWikiArticle}
+              onChange={(e) => setRequireWikiArticle(e.target.checked)}
+            />
+            Require Wiki Article
+          </label>
+        </div>
         <div>
           <button type="submit" className="Button u-mt2">
             Run Query

--- a/app/frontend/components/query-builder.component.tsx
+++ b/app/frontend/components/query-builder.component.tsx
@@ -27,6 +27,10 @@ export default function QueryBuilder() {
         type: string;
         value: string;
       };
+      person: {
+        type: string;
+        value: string;
+      };
     }[]
   >([]);
   const [languageCode, setLanguageCode] = useState<string>("");
@@ -160,15 +164,17 @@ export default function QueryBuilder() {
           </button>
         )}
         <div className="u-mt1">
-          <label>
+          <label className="CheckboxContainer">
             <input
               type="checkbox"
               checked={requireWikiArticle}
               onChange={(e) => setRequireWikiArticle(e.target.checked)}
+              className="CheckboxInput"
             />
-            Require Wiki Article
+            <span>Require Wiki Article</span>
           </label>
         </div>
+
         <div>
           <button type="submit" className="Button u-mt2">
             Run Query

--- a/app/frontend/styles/modules/query-builder.postcss
+++ b/app/frontend/styles/modules/query-builder.postcss
@@ -14,6 +14,25 @@
   transform: scale(1.2);
 }
 
+.CheckboxContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  padding: 5px;
+  transition: background-color 0.2s ease, transform 0.2s ease; /* Smooth transition */
+  &:hover {
+    background-color: #f0f0f0;
+    border-radius: 4px;
+  }
+}
+
+.CheckboxInput {
+  width: 20px;
+  height: 20px;
+  accent-color: $blue;
+}
+
 input.LanguageCodeInput {
   width: 185px;
   margin-bottom: 20px;
@@ -27,7 +46,7 @@ table {
     justify-content: space-between;
     align-items: center;
     .Button {
-      background-color: #34375b;
+      background-color: #676eb4;
     }
   }
 }

--- a/app/frontend/types/search-tool.type.tsx
+++ b/app/frontend/types/search-tool.type.tsx
@@ -15,6 +15,10 @@ type SPARQLResponse = {
         type: string;
         value: string;
       };
+      person: {
+        type: string;
+        value: string;
+      };
     }>;
   };
 };


### PR DESCRIPTION
This PR adds new functionality to the wikidata tool that allows users to fetch wikidata items with their labels even if those wikidata items don't belong to the chosen wikipedia version.

**Screenshot**
![image](https://github.com/user-attachments/assets/b3ebd3fc-420d-47b1-99b7-882e4e10df5c)
The old functionality (fetching only wikidata items that belong to a wikipedia article) is now moved to the "require wiki article" checkbox. While the new functionality is the default behavior.