### PR TITLE
Added petscan tool + improved csv filenames

### DIFF
--- a/app/frontend/components/CSV-button.component.tsx
+++ b/app/frontend/components/CSV-button.component.tsx
@@ -4,14 +4,16 @@ import { downloadAsCSV } from "../utils/search-utils";
 interface CSVButtonProps<T> {
   articles: T;
   csvConvert: (articles: T) => string;
+  filename: string;
 }
 export default function CSVButton<T>({
   articles,
   csvConvert,
+  filename,
 }: CSVButtonProps<T>) {
   const handleExportCSV = () => {
     const csvContent = csvConvert(articles);
-    downloadAsCSV(csvContent);
+    downloadAsCSV(csvContent, filename);
   };
   return (
     <button onClick={handleExportCSV} className="Button">

--- a/app/frontend/components/articles-table.component.tsx
+++ b/app/frontend/components/articles-table.component.tsx
@@ -18,6 +18,7 @@ export default function ArticlesTable({
               <CSVButton
                 articles={articles}
                 csvConvert={convertSPARQLArticlesToCSV}
+                filename="wikidata-articles.csv"
               />
             </th>
           </tr>

--- a/app/frontend/components/articles-table.component.tsx
+++ b/app/frontend/components/articles-table.component.tsx
@@ -5,8 +5,10 @@ import CSVButton from "./CSV-button.component";
 
 export default function ArticlesTable({
   articles,
+  qValueLabels,
 }: {
   articles: SPARQLResponse["results"]["bindings"];
+  qValueLabels: string[];
 }) {
   return (
     <>
@@ -18,7 +20,7 @@ export default function ArticlesTable({
               <CSVButton
                 articles={articles}
                 csvConvert={convertSPARQLArticlesToCSV}
-                filename="wikidata-articles.csv"
+                filename={`${qValueLabels.join("-")}-wikidata-articles.csv`}
               />
             </th>
           </tr>

--- a/app/frontend/components/category-tree.component.tsx
+++ b/app/frontend/components/category-tree.component.tsx
@@ -20,9 +20,11 @@ import { ArrowIcon, CheckBoxIcon } from "./tree-icons.component";
 export default function CategoryTree({
   treeData,
   languageCode,
+  categoryName,
 }: {
   treeData: CategoryNode;
   languageCode: string;
+  categoryName: string;
 }) {
   const [categoryTree, setCategoryTree] = useState<INode<IFlatMetadata>[]>(
     flattenTree(treeData)
@@ -262,7 +264,10 @@ export default function CategoryTree({
           }}
         />
       </div>
-      <SelectedNodesDisplay selectedNodes={manuallySelectedNodes} />
+      <SelectedNodesDisplay
+        categoryName={categoryName}
+        selectedNodes={manuallySelectedNodes}
+      />
     </div>
   );
 }

--- a/app/frontend/components/petscan-tool.tsx
+++ b/app/frontend/components/petscan-tool.tsx
@@ -80,7 +80,7 @@ export default function PetScanTool() {
                     <CSVButton
                       articles={articleTitles}
                       csvConvert={convertCategoryArticlesToCSV}
-                      filename="petscan-articles.csv"
+                      filename={`${petscanID}-petscan-articles.csv`}
                     />
                   </th>
                 </tr>

--- a/app/frontend/components/petscan-tool.tsx
+++ b/app/frontend/components/petscan-tool.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+
+export default function PetScanTool() {
+  const [petscanID, setPetscanID] = useState<string>("");
+  const [queryResult, setQueryResult] = useState(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!petscanID) {
+      alert("Please enter a PetScan ID.");
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `https://petscan.wmflabs.org/?psid=${petscanID}&format=json&origin=*`
+      );
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      const data = await response.json();
+      setQueryResult(data);
+    } catch (error) {
+      console.error("Fetch error:", error);
+      alert("There was an issue fetching the data.");
+    }
+  };
+
+  return (
+    <div className="Container Container--padded">
+      <h1>Impact Search</h1>
+
+      <form onSubmit={handleSubmit}>
+        <h3>Enter PetScan ID</h3>
+        <input
+          className="PetscanInput"
+          type="text"
+          value={petscanID}
+          onChange={(event) => setPetscanID(event.target.value)}
+          placeholder="PetScan ID"
+          required
+        />
+
+        <div>
+          <button type="submit" className="Button u-mt2">
+            Run Query
+          </button>
+        </div>
+      </form>
+
+      {queryResult && (
+        <div className="QueryResult">
+          <h3>Query Result</h3>
+          <pre>{JSON.stringify(queryResult, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/components/query-builder.component.tsx
+++ b/app/frontend/components/query-builder.component.tsx
@@ -187,7 +187,10 @@ export default function QueryBuilder() {
           <LoadingOval visible={isLoading} height="120" width="120" />
         </div>
       ) : articles.length > 0 ? (
-        <ArticlesTable articles={articles} />
+        <ArticlesTable
+          articles={articles}
+          qValueLabels={queryItemsData.map((item) => item.qValue.label)}
+        />
       ) : (
         ""
       )}

--- a/app/frontend/components/root.component.tsx
+++ b/app/frontend/components/root.component.tsx
@@ -36,6 +36,7 @@ function Root() {
                   <Link to="/search/wiki-dashboard-tool">
                     Education Dashboard Tool
                   </Link>
+                  <Link to="/search/petscan-tool">Petscan Tool</Link>
                 </div>
               </div>
             </div>

--- a/app/frontend/components/selected-nodes-display.component.tsx
+++ b/app/frontend/components/selected-nodes-display.component.tsx
@@ -39,6 +39,7 @@ export default function SelectedNodesDisplay({
       <CSVButton
         articles={selectedArticles.map((article) => article.articleTitle)}
         csvConvert={convertCategoryArticlesToCSV}
+        filename="wikicategory-articles.csv"
       />
       <h3 className="u-mt1">Selected Articles</h3>
       {selectedArticles.length} articles from {categoriesCount} categories

--- a/app/frontend/components/selected-nodes-display.component.tsx
+++ b/app/frontend/components/selected-nodes-display.component.tsx
@@ -8,8 +8,10 @@ import {
 import React from "react";
 
 export default function SelectedNodesDisplay({
+  categoryName,
   selectedNodes,
 }: {
+  categoryName: string;
   selectedNodes: Map<NodeId, INode<IFlatMetadata>>;
 }) {
   let categoriesCount = 0;
@@ -39,7 +41,7 @@ export default function SelectedNodesDisplay({
       <CSVButton
         articles={selectedArticles.map((article) => article.articleTitle)}
         csvConvert={convertCategoryArticlesToCSV}
-        filename="wikicategory-articles.csv"
+        filename={`${categoryName}-wikicategory-articles.csv`}
       />
       <h3 className="u-mt1">Selected Articles</h3>
       {selectedArticles.length} articles from {categoriesCount} categories

--- a/app/frontend/components/wiki-dashboard-tool.component.tsx
+++ b/app/frontend/components/wiki-dashboard-tool.component.tsx
@@ -15,6 +15,7 @@ import {
 
 export default function WikiDashboardTool() {
   const [courseURL, setCourseURL] = useState("");
+  const [courseSlug, setCourseSlug] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [usernames, setUsernames] = useState<string[]>();
   const [articleTitles, setArticleTitles] = useState<string[]>();
@@ -23,7 +24,7 @@ export default function WikiDashboardTool() {
     setIsLoading(true);
     event.preventDefault();
     try {
-      let { dashboardURL, type } = extractDashboardURLInfo(courseURL);
+      let { dashboardURL, type, slug } = extractDashboardURLInfo(courseURL);
 
       let [usersResponse, articlesResponse] = await Promise.allSettled([
         fetch(`${dashboardURL}/users.json`),
@@ -79,6 +80,7 @@ export default function WikiDashboardTool() {
 
       setUsernames(usernames);
       setArticleTitles(articleTitles);
+      setCourseSlug(slug);
     } catch (error) {
       if (error instanceof Error) {
         toast.error(error.message);
@@ -131,7 +133,7 @@ export default function WikiDashboardTool() {
                     <CSVButton
                       articles={articleTitles}
                       csvConvert={convertDashboardDataToCSV}
-                      filename="wikiarticles.csv"
+                      filename={`${courseSlug}-wikiarticles.csv`}
                     />
                   </th>
                 </tr>
@@ -156,7 +158,7 @@ export default function WikiDashboardTool() {
                     <CSVButton
                       articles={usernames}
                       csvConvert={convertDashboardDataToCSV}
-                      filename="wikiusernames.csv"
+                      filename={`${courseSlug}-wikiusernames.csv`}
                     />
                   </th>
                 </tr>

--- a/app/frontend/components/wiki-dashboard-tool.component.tsx
+++ b/app/frontend/components/wiki-dashboard-tool.component.tsx
@@ -131,6 +131,7 @@ export default function WikiDashboardTool() {
                     <CSVButton
                       articles={articleTitles}
                       csvConvert={convertDashboardDataToCSV}
+                      filename="wikiarticles.csv"
                     />
                   </th>
                 </tr>
@@ -155,6 +156,7 @@ export default function WikiDashboardTool() {
                     <CSVButton
                       articles={usernames}
                       csvConvert={convertDashboardDataToCSV}
+                      filename="wikiusernames.csv"
                     />
                   </th>
                 </tr>

--- a/app/frontend/components/wikipedia-category-page.component.tsx
+++ b/app/frontend/components/wikipedia-category-page.component.tsx
@@ -14,6 +14,7 @@ import { CheckBoxIcon } from "./tree-icons.component";
 
 export default function WikipediaCategoryPage() {
   const [categoryText, setCategoryText] = useState<string>("");
+  const [categoryName, setCategoryName] = useState<string>("");
   const [languageCode, setLanguageCode] = useState<string>("");
 
   const [SubcatsData, setSubcatsData] = useState<CategoryNode>();
@@ -41,6 +42,8 @@ export default function WikipediaCategoryPage() {
       if (fetchedSubcatsAndPages.error) {
         throw new Error(fetchedSubcatsAndPages.error.info);
       }
+      setCategoryName(categoryName);
+
       setSubcatsData(
         convertInitialResponseToTree(
           fetchedSubcatsAndPages,
@@ -116,7 +119,11 @@ export default function WikipediaCategoryPage() {
           <LoadingOval visible={isLoading} height="100" width="100" />
         </div>
       ) : SubcatsData ? (
-        <CategoryTree treeData={SubcatsData} languageCode={languageCode} />
+        <CategoryTree
+          categoryName={categoryName}
+          treeData={SubcatsData}
+          languageCode={languageCode}
+        />
       ) : (
         ""
       )}

--- a/app/frontend/entrypoints/index.tsx
+++ b/app/frontend/entrypoints/index.tsx
@@ -20,6 +20,7 @@ import WikipediaCategoryPage from "../components/wikipedia-category-page.compone
 import QueryBuilder from "../components/query-builder.component";
 import { Toaster } from "react-hot-toast";
 import WikiDashboardTool from "../components/wiki-dashboard-tool.component";
+import PetScanTool from "../components/petscan-tool";
 
 // Misc
 const queryClient = new QueryClient();
@@ -69,6 +70,10 @@ const router = createBrowserRouter([
       {
         path: "/search/wiki-dashboard-tool",
         element: <WikiDashboardTool />,
+      },
+      {
+        path: "/search/petscan-tool",
+        element: <PetScanTool />,
       },
     ],
   },

--- a/app/frontend/types/search-tool.type.tsx
+++ b/app/frontend/types/search-tool.type.tsx
@@ -148,6 +148,37 @@ type CampaignArticle = {
   wiki: { id: number; language: string; project: string };
 };
 
+type PetscanResponse = {
+  "*": [
+    {
+      a: {
+        "*": PetscanPage[];
+        type: "union";
+      };
+      n: string;
+    }
+  ];
+  a: {
+    query: string;
+    querytime_sec: number;
+  };
+  n: string;
+};
+
+type PetscanPage = {
+  id: number;
+  len: number;
+  metadata?: {
+    wikidata?: string;
+  };
+  n: string;
+  namespace: number;
+  nstext: string;
+  q: string;
+  title: string;
+  touched: string;
+};
+
 export type {
   SPARQLResponse,
   MediaWikiResponse,
@@ -158,4 +189,5 @@ export type {
   CourseArticlesResponse,
   CampaignUsersResponse,
   CampaignArticlesResponse,
+  PetscanResponse,
 };

--- a/app/frontend/utils/search-utils.ts
+++ b/app/frontend/utils/search-utils.ts
@@ -218,6 +218,7 @@ const removeDuplicateArticles = (
 function extractDashboardURLInfo(url: string): {
   dashboardURL: string;
   type: string;
+  slug: string;
 } {
   const protocolIndex = url.indexOf("://");
   if (protocolIndex === -1) {
@@ -229,14 +230,16 @@ function extractDashboardURLInfo(url: string): {
   // Remove trailing slashes and then split
   const parts = urlAfterProtocol.replace(/\/+$/, "").split("/");
 
+  let course_slug = "";
   let maxPartsLength: number;
   let type: string;
-
   if (parts[1] === "campaigns") {
     maxPartsLength = 3;
+    course_slug = parts[2];
     type = "campaign";
   } else if (parts[1] === "courses") {
     maxPartsLength = 4;
+    course_slug = `${parts[2]}-${parts[3]}`;
     type = "course";
   } else {
     throw new Error("Invalid URL: unrecognized path");
@@ -250,9 +253,11 @@ function extractDashboardURLInfo(url: string): {
 
   const extractedUrl =
     url.slice(0, protocolIndex + 3) + parts.slice(0, maxPartsLength).join("/");
+
   return {
     dashboardURL: extractedUrl,
     type: type,
+    slug: course_slug,
   };
 }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   get '/search/wikidata-tool', to: 'pages#index'
   get '/search/wikipedia-category-tool', to: 'pages#index'
   get '/search/wiki-dashboard-tool', to: 'pages#index'
+  get '/search/petscan-tool', to: 'pages#index'
 
   root "pages#index"
 end


### PR DESCRIPTION
Starts work on #24 
Closes #25 

This PR adds a new tool that allows users to input a petscan id and receive the article titles related to that id. The article titles can then be exported to CSV

**Video**

https://github.com/user-attachments/assets/2ac300a3-db93-4bf4-abe3-934616a4aab5

The exported CSV filenames have also been given more meaningful names. They are now:
`qvaluelabel1-qvaluelabel2-wikidata-articles.csv` for the wikidata tool (more labels are added here the more qvalues are used)
`petscanID-petscan-articles.csv` for the petscan tool
`categoryname-wikicategory-articles.csv` for the wikipedia category tool
`courseSlug-wikiarticles.csv` and `courseSlug-wikiusernames.csv` for the wiki dashboard tool
