### PR TITLE
Fixing Invalid CSV issue + implemented pagepile tool

### DIFF
--- a/app/frontend/components/articles-table.tsx
+++ b/app/frontend/components/articles-table.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { convertArticlesToCSV } from "../utils/search-utils";
+import CSVButton from "./CSV-button.component";
+
+export default function ArticlesTable({
+  articles,
+  filename,
+}: {
+  articles: string[];
+  filename: string;
+}) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Article
+            <CSVButton
+              articles={articles}
+              csvConvert={convertArticlesToCSV}
+              filename={filename}
+            />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {articles?.map((article, index) => (
+          <tr key={index}>
+            <td>
+              <div>{article}</div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/app/frontend/components/articles-table.tsx
+++ b/app/frontend/components/articles-table.tsx
@@ -9,28 +9,37 @@ export default function ArticlesTable({
   articles: string[];
   filename: string;
 }) {
+  const hasArticles = articles.length > 0;
   return (
     <table>
       <thead>
         <tr>
           <th>
             Article
-            <CSVButton
-              articles={articles}
-              csvConvert={convertArticlesToCSV}
-              filename={filename}
-            />
+            {hasArticles ? (
+              <CSVButton
+                articles={articles}
+                csvConvert={convertArticlesToCSV}
+                filename={filename}
+              />
+            ) : null}
           </th>
         </tr>
       </thead>
       <tbody>
-        {articles?.map((article, index) => (
-          <tr key={index}>
-            <td>
-              <div>{article}</div>
-            </td>
+        {hasArticles ? (
+          articles?.map((article, index) => (
+            <tr key={index}>
+              <td>
+                <div>{article}</div>
+              </td>
+            </tr>
+          ))
+        ) : (
+          <tr>
+            <td>No articles found</td>
           </tr>
-        ))}
+        )}
       </tbody>
     </table>
   );

--- a/app/frontend/components/pagepile-tool.tsx
+++ b/app/frontend/components/pagepile-tool.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from "react";
-import { PetscanResponse } from "../types/search-tool.type";
+import { PagePileResponse } from "../types/search-tool.type";
 import toast from "react-hot-toast";
 import LoadingOval from "./loading-oval.component";
 import CSVButton from "./CSV-button.component";
 import { convertArticlesToCSV } from "../utils/search-utils";
 
-export default function PetScanTool() {
-  const [petscanID, setPetscanID] = useState<string>("");
-  const [queryResult, setQueryResult] = useState<PetscanResponse>();
+export default function PagePileTool() {
+  const [pagePileID, setPagePileID] = useState<string>("");
+  const [queryResult, setQueryResult] = useState<PagePileResponse>();
   const [articleTitles, setArticleTitles] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -15,22 +15,22 @@ export default function PetScanTool() {
     setIsLoading(true);
     event.preventDefault();
 
-    if (!petscanID) {
-      toast("Please enter a PetScan ID.");
+    if (!pagePileID) {
+      toast("Please enter a PagePile ID.");
       return;
     }
 
     try {
       const response = await fetch(
-        `https://petscan.wmcloud.org/?psid=${petscanID}&format=json`
+        `https://pagepile.toolforge.org/api.php?id=${pagePileID}&action=get_data&format=json`
       );
       if (!response.ok) {
         throw new Error("Network response was not ok");
       }
-      const data: PetscanResponse = await response.json();
+      const data: PagePileResponse = await response.json();
       setQueryResult(data);
 
-      const titles = data["*"][0].a["*"].map((page) => page.title);
+      const titles = data.pages;
       setArticleTitles(titles);
     } catch (error) {
       console.error("Fetch error:", error);
@@ -45,13 +45,13 @@ export default function PetScanTool() {
       <h1>Impact Search</h1>
 
       <form onSubmit={handleSubmit}>
-        <h3>Enter PetScan ID</h3>
+        <h3>Enter PagePile ID</h3>
         <input
           className="PetscanInput"
           type="text"
-          value={petscanID}
-          onChange={(event) => setPetscanID(event.target.value)}
-          placeholder="PetScan ID"
+          value={pagePileID}
+          onChange={(event) => setPagePileID(event.target.value)}
+          placeholder="PagePile ID"
           required
         />
 
@@ -80,7 +80,7 @@ export default function PetScanTool() {
                     <CSVButton
                       articles={articleTitles}
                       csvConvert={convertArticlesToCSV}
-                      filename={`${petscanID}-petscan-articles.csv`}
+                      filename={`${pagePileID}-pagepile-articles.csv`}
                     />
                   </th>
                 </tr>

--- a/app/frontend/components/pagepile-tool.tsx
+++ b/app/frontend/components/pagepile-tool.tsx
@@ -4,6 +4,7 @@ import toast from "react-hot-toast";
 import LoadingOval from "./loading-oval.component";
 import CSVButton from "./CSV-button.component";
 import { convertArticlesToCSV } from "../utils/search-utils";
+import ArticlesTable from "./articles-table";
 
 export default function PagePileTool() {
   const [pagePileID, setPagePileID] = useState<string>("");
@@ -72,29 +73,10 @@ export default function PagePileTool() {
           style={{ display: "flex", gap: "20px" }}
         >
           {queryResult && (
-            <table>
-              <thead>
-                <tr>
-                  <th>
-                    Article
-                    <CSVButton
-                      articles={articleTitles}
-                      csvConvert={convertArticlesToCSV}
-                      filename={`${pagePileID}-pagepile-articles.csv`}
-                    />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {articleTitles?.map((article, index) => (
-                  <tr key={index}>
-                    <td>
-                      <div>{article}</div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <ArticlesTable
+              articles={articleTitles}
+              filename={`${pagePileID}-pagepile-articles.csv`}
+            />
           )}
         </div>
       )}

--- a/app/frontend/components/petscan-tool.tsx
+++ b/app/frontend/components/petscan-tool.tsx
@@ -4,6 +4,7 @@ import toast from "react-hot-toast";
 import LoadingOval from "./loading-oval.component";
 import CSVButton from "./CSV-button.component";
 import { convertArticlesToCSV } from "../utils/search-utils";
+import ArticlesTable from "./articles-table";
 
 export default function PetScanTool() {
   const [petscanID, setPetscanID] = useState<string>("");
@@ -72,29 +73,10 @@ export default function PetScanTool() {
           style={{ display: "flex", gap: "20px" }}
         >
           {queryResult && (
-            <table>
-              <thead>
-                <tr>
-                  <th>
-                    Article
-                    <CSVButton
-                      articles={articleTitles}
-                      csvConvert={convertArticlesToCSV}
-                      filename={`${petscanID}-petscan-articles.csv`}
-                    />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {articleTitles?.map((article, index) => (
-                  <tr key={index}>
-                    <td>
-                      <div>{article}</div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <ArticlesTable
+              articles={articleTitles}
+              filename={`${petscanID}-petscan-articles.csv`}
+            />
           )}
         </div>
       )}

--- a/app/frontend/components/query-builder.component.tsx
+++ b/app/frontend/components/query-builder.component.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types/search-tool.type";
 import QueryItem from "./query-item.component";
 import { buildWikidataQuery } from "../utils/search-utils";
-import ArticlesTable from "./articles-table.component";
+import SparqlArticlesTable from "./sparql-articles-table.component";
 import LoadingOval from "./loading-oval.component";
 import React from "react";
 import toast from "react-hot-toast";
@@ -127,6 +127,10 @@ export default function QueryBuilder() {
     return queriedArticlesJSON;
   }
 
+  const filename = `${queryItemsData
+    .map((item) => item.qValue.label)
+    .join("-")}-wikidata-articles.csv`;
+
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
@@ -187,10 +191,7 @@ export default function QueryBuilder() {
           <LoadingOval visible={isLoading} height="120" width="120" />
         </div>
       ) : articles.length > 0 ? (
-        <ArticlesTable
-          articles={articles}
-          qValueLabels={queryItemsData.map((item) => item.qValue.label)}
-        />
+        <SparqlArticlesTable articles={articles} filename={filename} />
       ) : (
         ""
       )}

--- a/app/frontend/components/root.component.tsx
+++ b/app/frontend/components/root.component.tsx
@@ -37,6 +37,7 @@ function Root() {
                     Education Dashboard Tool
                   </Link>
                   <Link to="/search/petscan-tool">Petscan Tool</Link>
+                  <Link to="/search/pagepile-tool">Pagepile Tool</Link>
                 </div>
               </div>
             </div>

--- a/app/frontend/components/selected-nodes-display.component.tsx
+++ b/app/frontend/components/selected-nodes-display.component.tsx
@@ -2,7 +2,7 @@ import { INode, NodeId } from "react-accessible-treeview";
 import { IFlatMetadata } from "react-accessible-treeview/dist/TreeView/utils";
 import CSVButton from "./CSV-button.component";
 import {
-  convertCategoryArticlesToCSV,
+  convertArticlesToCSV,
   removeDuplicateArticles,
 } from "../utils/search-utils";
 import React from "react";
@@ -40,7 +40,7 @@ export default function SelectedNodesDisplay({
     <div className="SelectedNodes Box">
       <CSVButton
         articles={selectedArticles.map((article) => article.articleTitle)}
-        csvConvert={convertCategoryArticlesToCSV}
+        csvConvert={convertArticlesToCSV}
         filename={`${categoryName}-wikicategory-articles.csv`}
       />
       <h3 className="u-mt1">Selected Articles</h3>

--- a/app/frontend/components/sparql-articles-table.component.tsx
+++ b/app/frontend/components/sparql-articles-table.component.tsx
@@ -3,12 +3,12 @@ import { convertSPARQLArticlesToCSV } from "../utils/search-utils";
 import { SPARQLResponse } from "../types/search-tool.type";
 import CSVButton from "./CSV-button.component";
 
-export default function ArticlesTable({
+export default function SparqlArticlesTable({
   articles,
-  qValueLabels,
+  filename,
 }: {
   articles: SPARQLResponse["results"]["bindings"];
-  qValueLabels: string[];
+  filename: string;
 }) {
   return (
     <>
@@ -20,7 +20,7 @@ export default function ArticlesTable({
               <CSVButton
                 articles={articles}
                 csvConvert={convertSPARQLArticlesToCSV}
-                filename={`${qValueLabels.join("-")}-wikidata-articles.csv`}
+                filename={filename}
               />
             </th>
           </tr>

--- a/app/frontend/components/wiki-dashboard-tool.component.tsx
+++ b/app/frontend/components/wiki-dashboard-tool.component.tsx
@@ -9,9 +9,10 @@ import {
 } from "../types/search-tool.type";
 import CSVButton from "./CSV-button.component";
 import {
-  convertDashboardDataToCSV,
+  convertArticlesToCSV,
   extractDashboardURLInfo,
 } from "../utils/search-utils";
+import ArticlesTable from "./articles-table";
 
 export default function WikiDashboardTool() {
   const [courseURL, setCourseURL] = useState("");
@@ -125,54 +126,16 @@ export default function WikiDashboardTool() {
           style={{ display: "flex", gap: "20px" }}
         >
           {articleTitles && articleTitles.length > 0 && (
-            <table>
-              <thead>
-                <tr>
-                  <th>
-                    Article
-                    <CSVButton
-                      articles={articleTitles}
-                      csvConvert={convertDashboardDataToCSV}
-                      filename={`${courseSlug}-wikiarticles.csv`}
-                    />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {articleTitles?.map((article, index) => (
-                  <tr key={index}>
-                    <td>
-                      <div>{article}</div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <ArticlesTable
+              articles={articleTitles}
+              filename={`${courseSlug}-wikiarticles.csv`}
+            />
           )}
           {usernames && usernames.length > 0 && (
-            <table>
-              <thead>
-                <tr>
-                  <th>
-                    User
-                    <CSVButton
-                      articles={usernames}
-                      csvConvert={convertDashboardDataToCSV}
-                      filename={`${courseSlug}-wikiusernames.csv`}
-                    />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {usernames?.map((username, index) => (
-                  <tr key={index}>
-                    <td>
-                      <div>{username}</div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <ArticlesTable
+              articles={usernames}
+              filename={`${courseSlug}-wikiusernames.csv`}
+            />
           )}
         </div>
       )}

--- a/app/frontend/entrypoints/index.tsx
+++ b/app/frontend/entrypoints/index.tsx
@@ -21,6 +21,7 @@ import QueryBuilder from "../components/query-builder.component";
 import { Toaster } from "react-hot-toast";
 import WikiDashboardTool from "../components/wiki-dashboard-tool.component";
 import PetScanTool from "../components/petscan-tool";
+import PagePileTool from "../components/pagepile-tool";
 
 // Misc
 const queryClient = new QueryClient();
@@ -74,6 +75,10 @@ const router = createBrowserRouter([
       {
         path: "/search/petscan-tool",
         element: <PetScanTool />,
+      },
+      {
+        path: "/search/pagepile-tool",
+        element: <PagePileTool />,
       },
     ],
   },

--- a/app/frontend/types/search-tool.type.tsx
+++ b/app/frontend/types/search-tool.type.tsx
@@ -165,6 +165,17 @@ type PetscanResponse = {
   n: string;
 };
 
+type PagePileResponse = {
+  pages: string[];
+  wiki: string;
+  id: number;
+  pages_returned: number;
+  pages_total: number;
+  sort_order: string;
+  language: string;
+  project: string;
+};
+
 type PetscanPage = {
   id: number;
   len: number;
@@ -190,4 +201,5 @@ export type {
   CampaignUsersResponse,
   CampaignArticlesResponse,
   PetscanResponse,
+  PagePileResponse,
 };

--- a/app/frontend/utils/search-utils.ts
+++ b/app/frontend/utils/search-utils.ts
@@ -72,16 +72,20 @@ function convertSPARQLArticlesToCSV(
   let csvContent = "data:text/csv;charset=utf-8,";
 
   articles.forEach((item) => {
-    csvContent += `"${item.personLabel.value}"\n`;
+    csvContent += `${escapeCSVSpecialCharacters(item.personLabel.value)}\n`;
   });
 
   return csvContent;
 }
 
+function escapeCSVSpecialCharacters(item: string): string {
+  return `"${item.replace(/"/g, '""')}"`;
+}
+
 function convertCategoryArticlesToCSV(articles: string[]): string {
   let csvContent = "data:text/csv;charset=utf-8,";
   for (const article of articles) {
-    csvContent += `"${article}"\n`;
+    csvContent += `${escapeCSVSpecialCharacters(article)}\n`;
   }
 
   return csvContent;
@@ -91,7 +95,7 @@ function convertDashboardDataToCSV(data: string[] | undefined): string {
   let csvContent = "data:text/csv;charset=utf-8,";
 
   data?.forEach((item) => {
-    csvContent += `"${item}"\n`;
+    csvContent += `${escapeCSVSpecialCharacters(item)}\n`;
   });
 
   return csvContent;

--- a/app/frontend/utils/search-utils.ts
+++ b/app/frontend/utils/search-utils.ts
@@ -82,7 +82,7 @@ function escapeCSVSpecialCharacters(item: string): string {
   return `"${item.replace(/"/g, '""')}"`;
 }
 
-function convertCategoryArticlesToCSV(articles: string[]): string {
+function convertArticlesToCSV(articles: string[]): string {
   let csvContent = "data:text/csv;charset=utf-8,";
   for (const article of articles) {
     csvContent += `${escapeCSVSpecialCharacters(article)}\n`;
@@ -268,7 +268,7 @@ function extractDashboardURLInfo(url: string): {
 export {
   buildWikidataQuery,
   convertSPARQLArticlesToCSV,
-  convertCategoryArticlesToCSV,
+  convertArticlesToCSV,
   convertDashboardDataToCSV,
   downloadAsCSV,
   convertInitialResponseToTree,

--- a/app/frontend/utils/search-utils.ts
+++ b/app/frontend/utils/search-utils.ts
@@ -91,16 +91,6 @@ function convertArticlesToCSV(articles: string[]): string {
   return csvContent;
 }
 
-function convertDashboardDataToCSV(data: string[] | undefined): string {
-  let csvContent = "data:text/csv;charset=utf-8,";
-
-  data?.forEach((item) => {
-    csvContent += `${escapeCSVSpecialCharacters(item)}\n`;
-  });
-
-  return csvContent;
-}
-
 function downloadAsCSV(csvContent: string, fileName = "data.csv"): void {
   const encodedUri = encodeURI(csvContent);
   const link = document.createElement("a");
@@ -269,7 +259,6 @@ export {
   buildWikidataQuery,
   convertSPARQLArticlesToCSV,
   convertArticlesToCSV,
-  convertDashboardDataToCSV,
   downloadAsCSV,
   convertInitialResponseToTree,
   convertResponseToTree,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   get '/search/wikipedia-category-tool', to: 'pages#index'
   get '/search/wiki-dashboard-tool', to: 'pages#index'
   get '/search/petscan-tool', to: 'pages#index'
+  get '/search/pagepile-tool', to: 'pages#index'
 
   root "pages#index"
 end


### PR DESCRIPTION
Fixes #27 
Closes #24 

This PR fixes an issue with the way CSVs are formatted currently in relation to the double quotes symbol
A fix has been applied to escape the double quotes as mentioned in the relevant issue

The PR also implements the pagepile tool and refactors the articlestable code for easier use of generic tables

**Screenshot:**
csv fix:
![image](https://github.com/user-attachments/assets/a3c25b48-46ad-40d3-b3ab-a3096099f74c)

pagepile tool:
![image](https://github.com/user-attachments/assets/2086a16c-5b4a-4bf8-b355-015119812a40)
