### PR TITLE
User set tool improvements and table pagination

### DIFF
--- a/app/frontend/components/articles-table.tsx
+++ b/app/frontend/components/articles-table.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { convertArticlesToCSV } from "../utils/search-utils";
 import CSVButton from "./CSV-button.component";
+import usePagination from "../hooks/usePagination";
 
 export default function ArticlesTable({
   articles,
@@ -9,38 +10,67 @@ export default function ArticlesTable({
   articles: string[];
   filename: string;
 }) {
+  const {
+    currentPageData,
+    currentPage,
+    totalPages,
+    nextPage,
+    prevPage,
+    goToPage,
+  } = usePagination<string>({
+    data: articles,
+    itemsPerPage: 15,
+    initialPage: 1,
+  });
+
   const hasArticles = articles.length > 0;
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>
-            Article
-            {hasArticles ? (
-              <CSVButton
-                articles={articles}
-                csvConvert={convertArticlesToCSV}
-                filename={filename}
-              />
-            ) : null}
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {hasArticles ? (
-          articles?.map((article, index) => (
-            <tr key={index}>
-              <td>
-                <div>{article}</div>
-              </td>
-            </tr>
-          ))
-        ) : (
+    <>
+      <table>
+        <thead>
           <tr>
-            <td>No articles found</td>
+            <th>
+              Article
+              {hasArticles ? (
+                <div>
+                  <button onClick={prevPage} disabled={currentPage === 1}>
+                    Prev
+                  </button>
+                  <span>
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <button
+                    onClick={nextPage}
+                    disabled={currentPage === totalPages}
+                  >
+                    Next
+                  </button>
+                  <CSVButton
+                    articles={articles}
+                    csvConvert={convertArticlesToCSV}
+                    filename={filename}
+                  />
+                </div>
+              ) : null}
+            </th>
           </tr>
-        )}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {hasArticles ? (
+            currentPageData?.map((article, index) => (
+              <tr key={index}>
+                <td>
+                  <div>{article}</div>
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td>No articles found</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </>
   );
 }

--- a/app/frontend/components/user-set-tool.tsx
+++ b/app/frontend/components/user-set-tool.tsx
@@ -54,19 +54,20 @@ export default function UserSetTool() {
       const data: UserSetResponse = await response.json();
       setQueriedData(data);
 
-      const usernames: string[] = [];
+      const usernames = new Set<string>();
 
       data.courses.forEach((course) => {
         course.students.forEach((student) => {
-          usernames.push(student.username);
+          usernames.add(student.username);
         });
         if (course.instructors) {
           course.instructors.forEach((instructor) => {
-            usernames.push(instructor.username);
+            usernames.add(instructor.username);
           });
         }
       });
-      setQueriedUsers(usernames);
+      const usernamesArray = Array.from(usernames);
+      setQueriedUsers(usernamesArray);
     } catch (error) {
       console.error("Fetch error:", error);
       toast("There was an issue fetching the data.");

--- a/app/frontend/hooks/usePagination.ts
+++ b/app/frontend/hooks/usePagination.ts
@@ -1,0 +1,69 @@
+import { useState } from "react";
+
+interface UsePaginationProps<T> {
+  data: T[];
+  itemsPerPage: number;
+  initialPage?: number;
+}
+
+interface UsePaginationReturn<T> {
+  currentPageData: T[];
+  currentPage: number;
+  totalPages: number;
+  nextPage: () => void;
+  prevPage: () => void;
+  goToPage: (pageNumber: number) => void;
+}
+
+function usePagination<T>({
+  data,
+  itemsPerPage,
+  initialPage = 1,
+}: UsePaginationProps<T>): UsePaginationReturn<T> {
+  const [currentPage, setCurrentPage] = useState<number>(initialPage);
+
+  const totalPages = Math.ceil(data.length / itemsPerPage);
+
+  if (currentPage > totalPages) {
+    setCurrentPage(totalPages);
+  } else if (currentPage < 1) {
+    setCurrentPage(1);
+  }
+
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const currentPageData = data.slice(startIndex, endIndex);
+
+  const nextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage((prev) => prev + 1);
+    }
+  };
+
+  const prevPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage((prev) => prev - 1);
+    }
+  };
+
+  const goToPage = (pageNumber: number) => {
+    if (pageNumber < 1) {
+      setCurrentPage(1);
+    } else if (pageNumber > totalPages) {
+      setCurrentPage(totalPages);
+    } else {
+      setCurrentPage(pageNumber);
+    }
+  };
+
+  return {
+    currentPageData,
+    currentPage,
+    totalPages,
+    nextPage,
+    prevPage,
+    goToPage,
+  };
+}
+
+export default usePagination;

--- a/app/frontend/types/search-tool.type.tsx
+++ b/app/frontend/types/search-tool.type.tsx
@@ -193,24 +193,12 @@ type PetscanPage = {
 export type UserSetResponse = {
   courses: {
     title: string;
-    created_at: string;
-    updated_at: string;
-    start: string;
-    end: string;
-    school: string;
-    term: string;
     slug: string;
     students: {
       username: string;
-      created_at: string;
-      updated_at: string;
-      permissions: number;
     }[];
     instructors?: {
       username: string;
-      created_at: string;
-      updated_at: string;
-      permissions: number;
     }[];
   }[];
 };


### PR DESCRIPTION
This PR adds client-side pagination for the articles table for easier navigation through big article sizes. It also fixes an issue where exported user set CSVs would save duplicate usernames due to how the data is returned,