### PR TITLE
Chart styling improvements, new csv export feature + new datapoint

### DIFF
--- a/app/frontend/components/topic-detail.component.tsx
+++ b/app/frontend/components/topic-detail.component.tsx
@@ -151,6 +151,10 @@ function renderStatBlocks({
             label: "Missing Articles",
             value: topic.missing_articles_count,
           },
+          {
+            label: "Total Average Daily Visits",
+            value: topic.total_average_daily_visits || 0,
+          },
         ]}
       />
 

--- a/app/frontend/components/topic-detail.component.tsx
+++ b/app/frontend/components/topic-detail.component.tsx
@@ -259,7 +259,6 @@ function TopicDetail() {
 
           {!hasTimepointStats && hasArticleAnalytics && (
             <div className="u-mt2">
-              <h3>Article Analytics</h3>
               <WikiBubbleChart
                 data={articleAnalytics}
                 actions

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useMemo } from "react";
 import vegaEmbed, { VisualizationSpec, EmbedOptions, Result } from "vega-embed";
+import CSVButton from "./CSV-button.component";
 
 type ArticleAnalytics = {
   average_daily_views: number;
@@ -23,6 +24,41 @@ interface WikiBubbleChartProps {
 }
 
 const HEIGHT = 650;
+
+function escapeCSV(text: string): string {
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function convertAnalyticsToCSV(
+  rows: Array<{
+    article: string;
+    average_daily_views: number;
+    prev_average_daily_views: number | null;
+    article_size: number;
+    prev_article_size: number | null;
+    lead_section_size: number;
+    talk_size: number;
+    prev_talk_size: number | null;
+  }>
+): string {
+  let csvContent = "data:text/csv;charset=utf-8,";
+  csvContent +=
+    "Article,Average Daily Views,Average Daily Views (prev year),Article Size,Article Size (prev year),Lead Section Size,Talk Size,Talk Size (prev year)\n";
+  rows.forEach((row) => {
+    csvContent +=
+      [
+        escapeCSV(row.article),
+        row.average_daily_views,
+        row.prev_average_daily_views ?? "",
+        row.article_size,
+        row.prev_article_size ?? "",
+        row.lead_section_size,
+        row.talk_size,
+        row.prev_talk_size ?? "",
+      ].join(",") + "\n";
+  });
+  return csvContent;
+}
 
 export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   data = {},
@@ -319,7 +355,14 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           alignItems: "center",
         }}
       >
-        <h2 className="u-mb0">Article analytics over chosen focus period</h2>
+        <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+          <h2 className="u-mb0">Article analytics over chosen focus period</h2>
+          <CSVButton
+            articles={rows}
+            csvConvert={convertAnalyticsToCSV}
+            filename="article-analytics"
+          />
+        </div>
 
         <div
           id={searchContainerId}

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useMemo } from "react";
 import vegaEmbed, { VisualizationSpec, EmbedOptions, Result } from "vega-embed";
 import CSVButton from "./CSV-button.component";
-import { convertAnalyticsToCSV } from "../utils/bubble-chart-utils";
+import {
+  convertAnalyticsToCSV,
+  getAssessmentColor,
+} from "../utils/bubble-chart-utils";
 
 type ArticleAnalytics = {
   average_daily_views: number;
@@ -11,7 +14,7 @@ type ArticleAnalytics = {
   prev_talk_size: number | null;
   lead_section_size: number;
   prev_average_daily_views: number | null;
-  assessment_grade?: string | null;
+  assessment_grade: string | null;
 };
 
 type Wiki = {
@@ -44,6 +47,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       return Object.entries(data).map(([article, analytics]) => ({
         article,
         ...analytics,
+        assessment_grade_color: getAssessmentColor(analytics.assessment_grade),
       }));
     }
     return [];
@@ -225,7 +229,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             cursor: "pointer",
             tooltip: {
               signal: `{
-                title: datum.article,
+                title: datum.assessment_grade ? '<div style=\"display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%\"><span>' + datum.article + '</span><span style=\"background-color:' + datum.assessment_grade_color + '; padding:2px 6px; border-radius:4px; color:#000; white-space:nowrap\">' + datum.assessment_grade + '</span></div>' : datum.article,
                 "Daily visits": format(datum.average_daily_views, ','),
                 "Daily visits (prev year)": isValid(datum.prev_average_daily_views) ? format(datum.prev_average_daily_views, ',') : 'n/a',
                 "Size": format(datum.article_size, ','),
@@ -279,6 +283,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       actions,
       renderer: "canvas",
       mode: "vega-lite",
+      tooltip: {
+        sanitize: (value: string) => value,
+      } as EmbedOptions["tooltip"],
     };
 
     vegaEmbed(containerRef.current, spec, options)

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useMemo } from "react";
 import vegaEmbed, { VisualizationSpec, EmbedOptions, Result } from "vega-embed";
 import CSVButton from "./CSV-button.component";
+import { convertAnalyticsToCSV } from "../utils/bubble-chart-utils";
 
 type ArticleAnalytics = {
   average_daily_views: number;
@@ -24,41 +25,6 @@ interface WikiBubbleChartProps {
 }
 
 const HEIGHT = 650;
-
-function escapeCSV(text: string): string {
-  return `"${text.replace(/"/g, '""')}"`;
-}
-
-function convertAnalyticsToCSV(
-  rows: Array<{
-    article: string;
-    average_daily_views: number;
-    prev_average_daily_views: number | null;
-    article_size: number;
-    prev_article_size: number | null;
-    lead_section_size: number;
-    talk_size: number;
-    prev_talk_size: number | null;
-  }>
-): string {
-  let csvContent = "data:text/csv;charset=utf-8,";
-  csvContent +=
-    "Article,Average Daily Views,Average Daily Views (prev year),Article Size,Article Size (prev year),Lead Section Size,Talk Size,Talk Size (prev year)\n";
-  rows.forEach((row) => {
-    csvContent +=
-      [
-        escapeCSV(row.article),
-        row.average_daily_views,
-        row.prev_average_daily_views ?? "",
-        row.article_size,
-        row.prev_article_size ?? "",
-        row.lead_section_size,
-        row.talk_size,
-        row.prev_talk_size ?? "",
-      ].join(",") + "\n";
-  });
-  return csvContent;
-}
 
 export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   data = {},

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -47,7 +47,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       return Object.entries(data).map(([article, analytics]) => ({
         article,
         ...analytics,
-        assessment_grade_color: getAssessmentColor(analytics.assessment_grade),
+        assessment_grade_color: getAssessmentColor(analytics?.assessment_grade),
       }));
     }
     return [];

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -307,6 +307,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         backgroundColor: "white",
         border: "1px solid #e0e0e0",
         padding: "0 24px",
+        width: "calc(100vw - 48px)",
+        marginLeft: "calc(-50vw + 50% + 24px)",
       }}
     >
       <div

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -304,24 +304,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   }, [rows, actions, wiki]);
 
   return (
-    <div
-      style={{
-        backgroundColor: "white",
-        border: "1px solid #e0e0e0",
-        padding: "0 24px",
-        width: "calc(100vw - 48px)",
-        marginLeft: "calc(-50vw + 50% + 24px)",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+    <div className="WikiBubbleChart">
+      <div className="WikiBubbleChartHeader">
+        <div className="WikiBubbleChartTitleRow">
           <h2 className="u-mb0">Article analytics over chosen focus period</h2>
           <CSVButton
             articles={rows}
@@ -332,109 +317,43 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
 
         <div
           id={searchContainerId}
-          style={{ display: "flex", justifyContent: "flex-end" }}
+          className="WikiBubbleChartSearchContainer"
         />
       </div>
 
       <div>
-        <style>
-          {`
-            .vega-bindings {
-              display: flex;
-              justify-content: center;
-              margin-bottom: 8px;
-            }
-          `}
-        </style>
-
-        <div
-          style={{
-            overflowY: "hidden",
-            width: "100%",
-          }}
-          ref={containerRef}
-        />
+        <div className="WikiBubbleChartChartContainer" ref={containerRef} />
       </div>
 
       {/* Legend */}
-      <div
-        style={{
-          marginTop: "8px",
-          display: "flex",
-          gap: "16px",
-          flexWrap: "wrap",
-          alignItems: "center",
-          fontSize: "0.9rem",
-        }}
-      >
+      <div className="WikiBubbleChartLegend">
         {/* Article size */}
-        <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-          <span
-            style={{
-              display: "inline-block",
-              width: "12px",
-              height: "12px",
-              borderRadius: "50%",
-              backgroundColor: "rgba(13, 71, 161, 0.5)",
-            }}
-          />
+        <div className="WikiBubbleChartLegendItem">
+          <span className="WikiBubbleChartLegendDotArticle" />
           <span>Article size (bytes)</span>
         </div>
 
         {/* Lead section size */}
-        <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-          <span
-            style={{
-              display: "inline-block",
-              width: "12px",
-              height: "12px",
-              borderRadius: "50%",
-              backgroundColor: "#90caf9",
-            }}
-          />
+        <div className="WikiBubbleChartLegendItem">
+          <span className="WikiBubbleChartLegendDotLead" />
           <span>Lead section size (bytes)</span>
         </div>
 
         {/* Discussion size */}
-        <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-          <span
-            style={{
-              display: "inline-block",
-              width: "12px",
-              height: "12px",
-              borderRadius: "50%",
-              border: "2px solid #2196f3",
-              backgroundColor: "transparent",
-            }}
-          />
+        <div className="WikiBubbleChartLegendItem">
+          <span className="WikiBubbleChartLegendRingDiscussion" />
           <span>Discussion size (bytes)</span>
         </div>
 
         {/* Previous article size */}
-        <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-          <span
-            style={{
-              display: "inline-block",
-              width: "12px",
-              height: "12px",
-              borderRadius: "50%",
-              border: "2px dashed #64b5f6",
-              backgroundColor: "transparent",
-            }}
-          />
+        <div className="WikiBubbleChartLegendItem">
+          <span className="WikiBubbleChartLegendRingPrevArticle" />
           <span>Prev. article size (bytes)</span>
         </div>
 
         {/* Daily views change (dotted line) */}
-        <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-          <span
-            style={{
-              display: "inline-block",
-              width: "16px",
-              height: "0",
-              borderTop: "2px dashed #757575",
-            }}
-          />
+        <div className="WikiBubbleChartLegendItem">
+          <span className="WikiBubbleChartLegendLineChange" />
           <span>Change in daily views</span>
         </div>
       </div>

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -11,6 +11,7 @@ type ArticleAnalytics = {
   prev_talk_size: number | null;
   lead_section_size: number;
   prev_average_daily_views: number | null;
+  assessment_grade?: string | null;
 };
 
 type Wiki = {
@@ -231,7 +232,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                 "Size (prev year)": isValid(datum.prev_article_size) ? format(datum.prev_article_size, ',') : 'n/a',
                 "Lead size": format(datum.lead_section_size, ','),
                 "Talk size": format(datum.talk_size, ','),
-                "Talk size (prev year)": isValid(datum.prev_talk_size) ? format(datum.prev_talk_size, ',') : 'n/a'
+                "Talk size (prev year)": isValid(datum.prev_talk_size) ? format(datum.prev_talk_size, ',') : 'n/a',
+                "Assessment": isValid(datum.assessment_grade) ? datum.assessment_grade : 'n/a'
               }`,
             },
           },

--- a/app/frontend/styles/js.postcss
+++ b/app/frontend/styles/js.postcss
@@ -25,5 +25,6 @@
 
   td.value {
     font-weight: 600;
+    text-align: right !important;
   }
 }

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -8,3 +8,91 @@ div[id^="search-container"] {
     }
   }
 }
+
+.vega-bindings {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.WikiBubbleChart {
+  background-color: white;
+  border: 1px solid #e0e0e0;
+  padding: 0 24px;
+  width: calc(100vw - 48px);
+  margin-left: calc(-50vw + 50% + 24px);
+
+  &Header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &TitleRow {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &SearchContainer {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &ChartContainer {
+    overflow-y: hidden;
+    width: 100%;
+  }
+
+  /* Legend */
+  &Legend {
+    margin-top: 8px;
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    align-items: center;
+    font-size: 0.9rem;
+
+    &Item {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    &DotArticle,
+    &DotLead,
+    &RingDiscussion,
+    &RingPrevArticle {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+
+    &DotArticle {
+      background-color: rgba(13, 71, 161, 0.5);
+    }
+
+    &DotLead {
+      background-color: #90caf9;
+    }
+
+    &RingDiscussion {
+      border: 2px solid #2196f3;
+      background-color: transparent;
+    }
+
+    &RingPrevArticle {
+      border: 2px dashed #64b5f6;
+      background-color: transparent;
+    }
+
+    &LineChange {
+      display: inline-block;
+      width: 16px;
+      height: 0;
+      border-top: 2px dashed #757575;
+    }
+  }
+}

--- a/app/frontend/utils/bubble-chart-utils.tsx
+++ b/app/frontend/utils/bubble-chart-utils.tsx
@@ -1,29 +1,31 @@
-export async function fetchAverageDailyViews({
-  topicId,
-  startDate,
-  endDate,
-}: {
-  topicId: number | string;
-  startDate?: string;
-  endDate?: string;
-}): Promise<number> {
-  const start = startDate ? new Date(startDate) : new Date();
-  const end = endDate ? new Date(endDate) : new Date();
-
-  const params = new URLSearchParams({
-    start_year: start.getFullYear().toString(),
-    end_year: end.getFullYear().toString(),
-    start_month: (start.getMonth() + 1).toString(),
-    start_day: start.getDate().toString(),
-    end_month: (end.getMonth() + 1).toString(),
-    end_day: end.getDate().toString(),
+import { escapeCSVSpecialCharacters } from "./search-utils";
+export function convertAnalyticsToCSV(
+  rows: Array<{
+    article: string;
+    average_daily_views: number;
+    prev_average_daily_views: number | null;
+    article_size: number;
+    prev_article_size: number | null;
+    lead_section_size: number;
+    talk_size: number;
+    prev_talk_size: number | null;
+  }>
+): string {
+  let csvContent = "data:text/csv;charset=utf-8,";
+  csvContent +=
+    "Article,Average Daily Views,Average Daily Views (prev year),Article Size,Article Size (prev year),Lead Section Size,Talk Size,Talk Size (prev year)\n";
+  rows.forEach((row) => {
+    csvContent +=
+      [
+        escapeCSVSpecialCharacters(row.article),
+        row.average_daily_views,
+        row.prev_average_daily_views ?? "",
+        row.article_size,
+        row.prev_article_size ?? "",
+        row.lead_section_size,
+        row.talk_size,
+        row.prev_talk_size ?? "",
+      ].join(",") + "\n";
   });
-
-  const url = `/api/topics/${topicId}/topic_article_analytics?${params}`;
-
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Failed to fetch pageviews: ${res.statusText}`);
-
-  const data = await res.json();
-  return data.average_daily_views || 0;
+  return csvContent;
 }

--- a/app/frontend/utils/bubble-chart-utils.tsx
+++ b/app/frontend/utils/bubble-chart-utils.tsx
@@ -1,4 +1,5 @@
 import { escapeCSVSpecialCharacters } from "./search-utils";
+
 export function convertAnalyticsToCSV(
   rows: Array<{
     article: string;
@@ -9,11 +10,12 @@ export function convertAnalyticsToCSV(
     lead_section_size: number;
     talk_size: number;
     prev_talk_size: number | null;
+    assessment_grade: string | null;
   }>
 ): string {
   let csvContent = "data:text/csv;charset=utf-8,";
   csvContent +=
-    "Article,Average Daily Views,Average Daily Views (prev year),Article Size,Article Size (prev year),Lead Section Size,Talk Size,Talk Size (prev year)\n";
+    "Article,Average Daily Views,Average Daily Views (prev year),Article Size,Article Size (prev year),Lead Section Size,Talk Size,Talk Size (prev year),Assessment Grade\n";
   rows.forEach((row) => {
     csvContent +=
       [
@@ -25,7 +27,34 @@ export function convertAnalyticsToCSV(
         row.lead_section_size,
         row.talk_size,
         row.prev_talk_size ?? "",
+        row.assessment_grade ?? "",
       ].join(",") + "\n";
   });
   return csvContent;
+}
+
+export function getAssessmentColor(grade?: string | null): string {
+  if (!grade) return "#9e9e9e";
+  switch (grade) {
+    case "FA":
+      return "#9CBDFF";
+    case "GA":
+      return "#66FF66";
+    case "A":
+      return "#66FFFF";
+    case "FL":
+      return "#9CBDFF";
+    case "B":
+      return "#B2FF66";
+    case "C":
+      return "#FFFF66";
+    case "Start":
+      return "#FFAA66";
+    case "Stub":
+      return "#FFA4A4";
+    case "List":
+      return "#C7B1FF";
+    default:
+      return "#9e9e9e";
+  }
 }

--- a/app/frontend/utils/search-utils.ts
+++ b/app/frontend/utils/search-utils.ts
@@ -307,4 +307,5 @@ export {
   extractDashboardURLInfo,
   extractDashboardUsername,
   convertTitlesToWikicode,
+  escapeCSVSpecialCharacters,
 };

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -138,11 +138,11 @@ class Topic < ApplicationRecord
   def article_analytics_data
     topic_article_analytics
       .joins(:article)
-      .pluck('articles.title', :average_daily_views, :prev_average_daily_views, :article_size, :prev_article_size, :talk_size, :prev_talk_size, :lead_section_size)
-      .map do |title, average_daily_views, prev_average_daily_views, article_size, prev_article_size, talk_size, prev_talk_size, lead_section_size|
+      .pluck('articles.title', :average_daily_views, :prev_average_daily_views, :article_size, :prev_article_size, :talk_size, :prev_talk_size, :lead_section_size, :assessment_grade)
+      .map do |title, average_daily_views, prev_average_daily_views, article_size, prev_article_size, talk_size, prev_talk_size, lead_section_size, assessment_grade|
         [title,
          { average_daily_views:, prev_average_daily_views:, article_size:, prev_article_size:, talk_size:, prev_talk_size:,
-           lead_section_size: }]
+           lead_section_size:, assessment_grade: }]
       end
       .to_h
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -127,6 +127,10 @@ class Topic < ApplicationRecord
     active_article_bag&.articles&.missing&.count || 0
   end
 
+  def total_average_daily_visits
+    topic_article_analytics.sum(:average_daily_views)
+  end
+
   def most_recent_summary
     topic_summaries.last
   end

--- a/app/models/topic_article_analytic.rb
+++ b/app/models/topic_article_analytic.rb
@@ -24,6 +24,7 @@ end
 #
 #  id                       :bigint           not null, primary key
 #  article_size             :integer
+#  assessment_grade         :string
 #  average_daily_views      :integer          default(0)
 #  lead_section_size        :integer
 #  prev_article_size        :integer

--- a/app/sidekiq/generate_article_analytics_job.rb
+++ b/app/sidekiq/generate_article_analytics_job.rb
@@ -62,7 +62,8 @@ class GenerateArticleAnalyticsJob
         talk_size: fetch_talk_size(article_stats_service:, article:, date: end_date),
         prev_talk_size: fetch_talk_size(article_stats_service:, article:, date: prev_end_date),
         lead_section_size: fetch_lead_section_size(article_stats_service:, article:,
-                                                   date: end_date)
+                                                   date: end_date),
+        assessment_grade: fetch_assessment_grade(article_stats_service:, article:)
       )
 
       Rails.logger.info("[GenerateArticleAnalyticsJob] Saved analytics for #{article.title} - average_views: #{average_views.round}, prev_average_views: #{prev_average_views&.round}, article_size: #{topic_article_analytic.article_size}, prev_article_size: #{topic_article_analytic.prev_article_size}, talk_size: #{topic_article_analytic.talk_size}, prev_talk_size: #{topic_article_analytic.prev_talk_size}, lead_section_size: #{topic_article_analytic.lead_section_size}")
@@ -100,6 +101,14 @@ class GenerateArticleAnalyticsJob
     article_stats_service.get_lead_section_size_at_date(article:, date:)
   rescue StandardError => e
     Rails.logger.error("[GenerateArticleAnalyticsJob] Error fetching lead section size for #{article.title}: #{e.message}")
+    nil
+  end
+
+  def fetch_assessment_grade(article_stats_service:, article:)
+    Rails.logger.info("[GenerateArticleAnalyticsJob] Fetching assessment grade for #{article.title}")
+    article_stats_service.get_page_assessment_grade(article:)
+  rescue StandardError => e
+    Rails.logger.error("[GenerateArticleAnalyticsJob] Error fetching assessment for #{article.title}: #{e.message}")
     nil
   end
 end

--- a/app/views/topics/_topic.jbuilder
+++ b/app/views/topics/_topic.jbuilder
@@ -4,7 +4,8 @@ owned = current_topic_editor&.can_edit_topic?(topic) || false
 
 json.extract! topic, :id, :name, :description, :end_date, :slug,
               :start_date, :timepoint_day_interval, :user_count, :editor_label,
-              :chart_time_unit, :wiki_id, :articles_count, :missing_articles_count, :users_csv_url,
+              :chart_time_unit, :wiki_id, :articles_count, :missing_articles_count,
+              :total_average_daily_visits, :users_csv_url,
               :users_csv_filename, :articles_csv_url, :articles_csv_filename,
               :timepoint_generate_job_id, :users_import_job_id, :article_import_job_id,
               :timepoints_count, :summaries_count, :tokens_per_word, :convert_tokens_to_words,

--- a/db/migrate/20250901123000_add_assessment_grade_to_topic_article_analytics.rb
+++ b/db/migrate/20250901123000_add_assessment_grade_to_topic_article_analytics.rb
@@ -1,0 +1,7 @@
+class AddAssessmentGradeToTopicArticleAnalytics < ActiveRecord::Migration[7.0]
+  def change
+    add_column :topic_article_analytics, :assessment_grade, :string
+  end
+end
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_14_120000) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_01_123000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -143,6 +143,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_14_120000) do
     t.integer "prev_talk_size"
     t.integer "lead_section_size"
     t.integer "prev_average_daily_views"
+    t.string "assessment_grade"
     t.index ["topic_id", "article_id"], name: "index_topic_article_analytics_on_topic_id_and_article_id", unique: true
   end
 

--- a/lib/wiki_action_api.rb
+++ b/lib/wiki_action_api.rb
@@ -222,6 +222,24 @@ class WikiActionApi
     response.data.dig('pages', 0, 'revisions', 0, 'content') if response&.status == 200
   end
 
+  def get_page_assessments(pageid: nil, title: nil)
+    query_parameters = {
+      prop: 'pageassessments',
+      redirects: true,
+      palimit: 'max',
+      formatversion: '2'
+    }
+
+    query_parameters['pageids'] = [pageid] if pageid
+    query_parameters['titles'] = [title] if title
+
+    response = query(query_parameters:)
+
+    return nil unless response&.status == 200
+
+    response.data.dig('pages', 0, 'pageassessments')
+  end
+
   private
 
   def api_client


### PR DESCRIPTION
This PR adds a bunch of new features/changes:
- Increased chart width for article analytics chart
- Added export to CSV feature for article analytics chart
- Adds new stat that tracks the total average daily views across all articles in a topic (can be seen on the article analytics statblock)
- Adds new assessment grade datapoint, this represents the assessment grade given to each wikipedia article (taken from the Project-independent assessment rating)

**Video**

https://github.com/user-attachments/assets/7cb77acb-f53d-4593-a7fa-aa833cc91340

