### PR TITLE
Topic Builder → Impact Visualizer handoff (IV side)

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -36,8 +36,12 @@ class ImportsController < ApplicationController
     importer = TopicBuilderImportService.new(package: package, topic_editor: current_admin_user)
     topic = importer.import!
 
-    job_id = ImportTopicBuilderArticlesJob.perform_async(topic.id, @handle)
-    topic.update(article_import_job_id: job_id)
+    # Pre-generate the jid and write it to the topic BEFORE enqueueing,
+    # so a fast worker can't finish the job (and clear the column) before
+    # the controller has a chance to record the id.
+    jid = SecureRandom.hex(12)
+    topic.update!(article_import_job_id: jid)
+    ImportTopicBuilderArticlesJob.set(jid: jid).perform_async(topic.id, @handle)
 
     article_count = package['article_count'] || package.fetch('articles', []).size
     redirect_to "/topics/#{topic.id}",

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -36,9 +36,12 @@ class ImportsController < ApplicationController
     importer = TopicBuilderImportService.new(package: package, topic_editor: current_admin_user)
     topic = importer.import!
 
-    redirect_to "/topics/#{topic.slug}",
-                allow_other_host: false,
-                notice: "Imported '#{topic.name}' with #{topic.articles_count} articles from Topic Builder."
+    job_id = ImportTopicBuilderArticlesJob.perform_async(topic.id, @handle)
+    topic.update(article_import_job_id: job_id)
+
+    article_count = package['article_count'] || package.fetch('articles', []).size
+    redirect_to "/topics/#{topic.id}",
+                notice: "Imported '#{topic.name}'. Ingesting #{article_count} articles in the background."
   rescue TopicBuilderPackageService::NotFound
     render :not_found, status: :not_found
   rescue TopicBuilderPackageService::SchemaVersionError => e

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Handles the Topic Builder → Impact Visualizer handoff flow.
+# GET  /imports/:handle  renders a preview from the TB package.
+# POST /imports/:handle  creates the Topic + ArticleBag in a transaction.
+#
+# v1 is admin-only on POST (matches the rest of IV's import surface area,
+# which lives behind ActiveAdmin). The GET preview is also admin-only for
+# v1; broaden in lockstep when POST opens up to authenticated editors.
+class ImportsController < ApplicationController
+  PREVIEW_ARTICLE_LIMIT = 10
+
+  before_action :authenticate_admin_user!
+  before_action :set_handle
+
+  layout false
+
+  def show
+    @package = TopicBuilderPackageService.fetch(@handle)
+    TopicBuilderPackageService.assert_supported_schema!(@package)
+    @first_articles = @package.fetch('articles', []).first(PREVIEW_ARTICLE_LIMIT)
+  rescue TopicBuilderPackageService::NotFound
+    render :not_found, status: :not_found
+  rescue TopicBuilderPackageService::SchemaVersionError => e
+    @schema_version = e.schema_version
+    render :schema_mismatch, status: :unprocessable_entity
+  rescue TopicBuilderPackageService::NetworkError => e
+    @network_error = e.message
+    render :network_error, status: :bad_gateway
+  end
+
+  def create
+    package = TopicBuilderPackageService.fetch(@handle)
+    TopicBuilderPackageService.assert_supported_schema!(package)
+
+    importer = TopicBuilderImportService.new(package: package, topic_editor: current_admin_user)
+    topic = importer.import!
+
+    redirect_to "/topics/#{topic.slug}",
+                allow_other_host: false,
+                notice: "Imported '#{topic.name}' with #{topic.articles_count} articles from Topic Builder."
+  rescue TopicBuilderPackageService::NotFound
+    render :not_found, status: :not_found
+  rescue TopicBuilderPackageService::SchemaVersionError => e
+    @schema_version = e.schema_version
+    render :schema_mismatch, status: :unprocessable_entity
+  rescue TopicBuilderPackageService::NetworkError => e
+    @network_error = e.message
+    render :network_error, status: :bad_gateway
+  rescue TopicBuilderImportService::UnknownWikiError => e
+    @import_error = e.message
+    render :import_error, status: :unprocessable_entity
+  rescue TopicBuilderImportService::ValidationError => e
+    @import_error = e.message
+    render :import_error, status: :unprocessable_entity
+  end
+
+  private
+
+  def set_handle
+    @handle = params[:handle].to_s
+  end
+end

--- a/app/frontend/components/topic-action.component.tsx
+++ b/app/frontend/components/topic-action.component.tsx
@@ -19,7 +19,15 @@ const actions = {
     label: "Articles",
     buttonLabel: "Import Articles from CSV",
     isReady: (topic: Topic) => {
-      return !!topic.articles_csv_filename;
+      // TB-imported topics never need a CSV — articles arrive via the
+      // Topic Builder package (and may still be ingesting in the
+      // background, in which case articles_count is 0 but the action
+      // panel should show progress, not a CSV upload form).
+      return (
+        !!topic.articles_csv_filename ||
+        topic.articles_count > 0 ||
+        !!topic.tb_handle
+      );
     },
     isBusy: (topic: Topic) => {
       return topic.articles_import_status !== "idle";

--- a/app/frontend/components/topic-actions.component.tsx
+++ b/app/frontend/components/topic-actions.component.tsx
@@ -14,30 +14,34 @@ import TopicAction from "./topic-action.component";
 function renderActions({ topic, setCanEditTopic }) {
   const output: React.JSX.Element[] = [];
   const actions: String[] = [];
-  let proceed = true;
 
-  if (
-    topic.user_count > 0 &&
-    topic.articles_count > 0 &&
+  // Topic Builder imports own the article (and eventually the user)
+  // list; the CSV upload UI doesn't apply. Until TB starts emitting
+  // users, a TB topic just runs with 0 users — the backend allows it.
+  const isTbTopic = !!topic.tb_handle;
+
+  const importsSettled =
     (!topic.users_import_status ||
       topic.users_import_status === "idle" ||
       topic.users_import_status === "complete") &&
     (!topic.articles_import_status ||
       topic.articles_import_status === "idle" ||
-      topic.articles_import_status === "complete")
+      topic.articles_import_status === "complete");
+
+  // Backend (TopicService#incremental_topic_build) only requires articles,
+  // not users. CSV-driven topics historically gated on user_count > 0 too;
+  // keep that for non-TB topics so the prior UX is preserved.
+  if (
+    topic.articles_count > 0 &&
+    importsSettled &&
+    (isTbTopic || topic.user_count > 0)
   ) {
-    // actions.push('timepoints');
     actions.push("incremental_topic_build");
-    proceed = true;
   }
 
-  actions.push("users");
-  if (!topic.users_csv_filename) proceed = false;
-
-  if (proceed) {
-    actions.push("articles");
-    actions.push("article_analytics");
-  }
+  if (!isTbTopic) actions.push("users");
+  actions.push("articles");
+  actions.push("article_analytics");
 
   actions.forEach((action) => {
     output.push(

--- a/app/frontend/components/topic-actions.component.tsx
+++ b/app/frontend/components/topic-actions.component.tsx
@@ -20,21 +20,21 @@ function renderActions({ topic, setCanEditTopic }) {
   // users, a TB topic just runs with 0 users — the backend allows it.
   const isTbTopic = !!topic.tb_handle;
 
-  const importsSettled =
-    (!topic.users_import_status ||
-      topic.users_import_status === "idle" ||
-      topic.users_import_status === "complete") &&
-    (!topic.articles_import_status ||
-      topic.articles_import_status === "idle" ||
-      topic.articles_import_status === "complete");
+  const isSettled = (status: string) =>
+    !status || status === "idle" || status === "complete";
 
   // Backend (TopicService#incremental_topic_build) only requires articles,
   // not users. CSV-driven topics historically gated on user_count > 0 too;
-  // keep that for non-TB topics so the prior UX is preserved.
+  // keep that for non-TB topics so the prior UX is preserved. TB topics
+  // also skip the users_import_status check — they never run a user
+  // import, so a stale users_import_job_id from a different code path
+  // shouldn't keep blocking timepoint generation.
   if (
     topic.articles_count > 0 &&
-    importsSettled &&
-    (isTbTopic || topic.user_count > 0)
+    isSettled(topic.articles_import_status) &&
+    (isTbTopic
+      ? true
+      : topic.user_count > 0 && isSettled(topic.users_import_status))
   ) {
     actions.push("incremental_topic_build");
   }

--- a/app/frontend/types/topic.type.tsx
+++ b/app/frontend/types/topic.type.tsx
@@ -54,4 +54,5 @@ export default interface Topic {
   classifications: Array<Classification>;
   convert_tokens_to_words: boolean;
   tokens_per_word: number;
+  tb_handle: string | null;
 }

--- a/app/models/article_bag_article.rb
+++ b/app/models/article_bag_article.rb
@@ -5,9 +5,13 @@ class ArticleBagArticle < ApplicationRecord
   belongs_to :article_bag
   belongs_to :article
 
+  # Validations
+  validates :centrality, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10 },
+                         allow_nil: true
+
   # For ActiveAdmin
   def self.ransackable_attributes(auth_object = nil)
-    ["article_bag_id", "article_id", "created_at", "id", "updated_at"]
+    ["article_bag_id", "article_id", "centrality", "created_at", "id", "updated_at"]
   end
 
 end
@@ -17,6 +21,7 @@ end
 # Table name: article_bag_articles
 #
 #  id             :bigint           not null, primary key
+#  centrality     :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  article_bag_id :bigint           not null

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -288,7 +288,7 @@ class Topic < ApplicationRecord
   # For ActiveAdmin
   def self.ransackable_attributes(_auth_object = nil)
     %w[chart_time_unit created_at description display editor_label end_date id name
-       slug start_date timepoint_day_interval updated_at words_per_token
+       slug start_date tb_handle timepoint_day_interval updated_at words_per_token
        convert_tokens_to_words wiki_id]
   end
 end
@@ -314,6 +314,7 @@ end
 #  article_import_job_id             :string
 #  generate_article_analytics_job_id :string
 #  incremental_topic_build_job_id    :string
+#  tb_handle                         :string
 #  timepoint_generate_job_id         :string
 #  users_import_job_id               :string
 #  wiki_id                           :integer

--- a/app/services/topic_builder_import_service.rb
+++ b/app/services/topic_builder_import_service.rb
@@ -50,8 +50,7 @@ class TopicBuilderImportService
         tb_handle: handle
       )
 
-      bag = ArticleBag.create!(topic: topic, name: "#{topic.slug.titleize} Articles")
-      attach_articles!(bag, wiki)
+      ArticleBag.create!(topic: topic, name: "#{topic.slug.titleize} Articles")
 
       if topic_editor && !topic_editor.is_a?(AdminUser)
         topic_editor.topics << topic
@@ -69,18 +68,5 @@ class TopicBuilderImportService
     wiki = Wiki.find_by(language: language, project: 'wikipedia')
     raise UnknownWikiError.new(language) unless wiki
     wiki
-  end
-
-  def attach_articles!(bag, wiki)
-    package.fetch('articles', []).each do |entry|
-      title = entry['title'].to_s
-      next if title.empty?
-      article = Article.find_or_create_by!(title: title, wiki: wiki)
-      ArticleBagArticle.create!(
-        article_bag: bag,
-        article: article,
-        centrality: entry['centrality']
-      )
-    end
   end
 end

--- a/app/services/topic_builder_import_service.rb
+++ b/app/services/topic_builder_import_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Creates a Topic, ArticleBag, and ArticleBagArticles from a Topic Builder
+# package payload (already fetched + schema-validated). Atomic per-topic
+# transaction; surfaces a structured error so the controller can render an
+# actionable message.
+class TopicBuilderImportService
+  class Error < StandardError; end
+  class UnknownWikiError < Error
+    attr_reader :language
+    def initialize(language)
+      @language = language
+      super("Impact Visualizer is not configured for the '#{language}' wiki.")
+    end
+  end
+  class ValidationError < Error
+    attr_reader :record
+    def initialize(record)
+      @record = record
+      super(record.errors.full_messages.join('; '))
+    end
+  end
+
+  attr_reader :package, :handle, :topic_editor
+
+  # topic_editor: the editor or admin to associate with the new topic (so
+  # non-admin owners can manage their own topics later, when v1's
+  # admin-only POST gate is broadened).
+  def initialize(package:, topic_editor: nil)
+    @package = package
+    @handle = package['handle']
+    @topic_editor = topic_editor
+  end
+
+  def import!
+    config = package.fetch('config')
+    wiki = resolve_wiki!(config['wiki'])
+
+    Topic.transaction do
+      topic = Topic.create!(
+        name: config['name'],
+        slug: config['slug'],
+        description: config['description'],
+        editor_label: config['editor_label'],
+        start_date: config['start_date'],
+        end_date: config['end_date'],
+        timepoint_day_interval: config['timepoint_day_interval'],
+        wiki: wiki,
+        display: false,
+        tb_handle: handle
+      )
+
+      bag = ArticleBag.create!(topic: topic, name: "#{topic.slug.titleize} Articles")
+      attach_articles!(bag, wiki)
+
+      if topic_editor && !topic_editor.is_a?(AdminUser)
+        topic_editor.topics << topic
+      end
+
+      topic
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    raise ValidationError.new(e.record)
+  end
+
+  private
+
+  def resolve_wiki!(language)
+    wiki = Wiki.find_by(language: language, project: 'wikipedia')
+    raise UnknownWikiError.new(language) unless wiki
+    wiki
+  end
+
+  def attach_articles!(bag, wiki)
+    package.fetch('articles', []).each do |entry|
+      title = entry['title'].to_s
+      next if title.empty?
+      article = Article.find_or_create_by!(title: title, wiki: wiki)
+      ArticleBagArticle.create!(
+        article_bag: bag,
+        article: article,
+        centrality: entry['centrality']
+      )
+    end
+  end
+end

--- a/app/services/topic_builder_package_service.rb
+++ b/app/services/topic_builder_package_service.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+# Fetches and validates a TB→IV handoff package from topic-builder.
+# Spec: docs/wikipedia-topic-builder-impact-visualizer.md (or upstream)
+class TopicBuilderPackageService
+  SUPPORTED_SCHEMA_VERSION = 1
+  HANDLE_PREFIX = 'tbp_'
+  TIMEOUT_SECONDS = 20
+
+  class Error < StandardError; end
+  class NotFound < Error; end
+  class NetworkError < Error; end
+  class SchemaVersionError < Error
+    attr_reader :schema_version
+    def initialize(schema_version)
+      @schema_version = schema_version
+      super("Unsupported package schema_version: #{schema_version.inspect}")
+    end
+  end
+
+  def self.base_url
+    ENV.fetch('TOPIC_BUILDER_BASE_URL', 'https://topic-builder.wikiedu.org')
+  end
+
+  def self.valid_handle?(handle)
+    handle.is_a?(String) && handle.start_with?(HANDLE_PREFIX)
+  end
+
+  def self.fetch(handle)
+    raise NotFound, 'invalid handle' unless valid_handle?(handle)
+
+    uri = URI.join("#{base_url}/", "packages/#{handle}")
+    response = http_get_with_retry(uri)
+
+    case response
+    when Net::HTTPNotFound
+      raise NotFound, 'package not found or expired'
+    when Net::HTTPSuccess
+      JSON.parse(response.body)
+    else
+      raise NetworkError, "unexpected response: #{response.code} #{response.message}"
+    end
+  rescue JSON::ParserError => e
+    raise NetworkError, "invalid JSON in package response: #{e.message}"
+  rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNREFUSED => e
+    raise NetworkError, "network error fetching package: #{e.message}"
+  end
+
+  # Retry once on 5xx; surface the rest.
+  def self.http_get_with_retry(uri)
+    response = http_get(uri)
+    response = http_get(uri) if response.is_a?(Net::HTTPServerError)
+    response
+  end
+
+  def self.http_get(uri)
+    Net::HTTP.start(
+      uri.host, uri.port,
+      use_ssl: uri.scheme == 'https',
+      open_timeout: TIMEOUT_SECONDS, read_timeout: TIMEOUT_SECONDS
+    ) do |http|
+      http.request(Net::HTTP::Get.new(uri.request_uri))
+    end
+  end
+
+  def self.assert_supported_schema!(package)
+    return if package['schema_version'] == SUPPORTED_SCHEMA_VERSION
+    raise SchemaVersionError.new(package['schema_version'])
+  end
+end

--- a/app/sidekiq/import_topic_builder_articles_job.rb
+++ b/app/sidekiq/import_topic_builder_articles_job.rb
@@ -9,6 +9,14 @@ class ImportTopicBuilderArticlesJob
   include Sidekiq::Status::Worker
   sidekiq_options queue: 'import', retry: 3
 
+  # When all retries are spent, clear article_import_job_id so the topic
+  # isn't permanently stuck in a "queued" state. The user can then delete
+  # and re-import (or, future-self, click a Retry button).
+  sidekiq_retries_exhausted do |msg, _ex|
+    topic_id = msg['args'].first
+    Topic.where(id: topic_id).update_all(article_import_job_id: nil)
+  end
+
   EXPIRATION_SECONDS = 60 * 60 * 24 * 30
 
   def perform(topic_id, handle)

--- a/app/sidekiq/import_topic_builder_articles_job.rb
+++ b/app/sidekiq/import_topic_builder_articles_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Background article-ingestion for a Topic Builder handoff. The
+# ImportsController creates the Topic + empty ArticleBag synchronously
+# (so the user gets an instant redirect to the new topic page) and then
+# enqueues this job to populate ArticleBagArticles row-by-row.
+class ImportTopicBuilderArticlesJob
+  include Sidekiq::Job
+  include Sidekiq::Status::Worker
+  sidekiq_options queue: 'import', retry: 3
+
+  EXPIRATION_SECONDS = 60 * 60 * 24 * 30
+
+  def perform(topic_id, handle)
+    @expiration = EXPIRATION_SECONDS
+
+    topic = Topic.find(topic_id)
+    bag = topic.active_article_bag
+    raise "Topic #{topic_id} has no active article bag" unless bag
+
+    package = TopicBuilderPackageService.fetch(handle)
+    TopicBuilderPackageService.assert_supported_schema!(package)
+
+    entries = package.fetch('articles', [])
+    total(entries.size)
+
+    entries.each_with_index do |entry, idx|
+      ingest_one(bag, topic.wiki, entry)
+      at(idx + 1)
+    end
+
+    topic.reload.update(article_import_job_id: nil)
+  end
+
+  def expiration
+    @expiration ||= EXPIRATION_SECONDS
+  end
+
+  private
+
+  def ingest_one(bag, wiki, entry)
+    title = entry['title'].to_s
+    return if title.empty?
+
+    article = Article.find_or_create_by!(title: title, wiki: wiki)
+    ArticleBagArticle.find_or_create_by!(article_bag: bag, article: article) do |aba|
+      aba.centrality = entry['centrality']
+    end
+  end
+end

--- a/app/sidekiq/import_topic_builder_articles_job.rb
+++ b/app/sidekiq/import_topic_builder_articles_job.rb
@@ -30,6 +30,15 @@ class ImportTopicBuilderArticlesJob
     end
 
     topic.reload.update(article_import_job_id: nil)
+
+    # The TB handoff is meant to be a one-click flow: after the user
+    # clicks Import, they should land on the topic page and watch all
+    # the data populate without further intervention. Kick off article
+    # analytics and the full incremental timepoint build pipeline in
+    # parallel; both jobs lazily populate per-article details on the
+    # fly when they encounter an article without them.
+    topic.queue_generate_article_analytics
+    topic.queue_incremental_topic_build(queue_next_stage: true, force_updates: false)
   end
 
   def expiration

--- a/app/views/imports/_layout_head.html.erb
+++ b/app/views/imports/_layout_head.html.erb
@@ -1,0 +1,19 @@
+<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600', media: 'all' %>
+<%= csrf_meta_tags %>
+<style>
+  body { font-family: 'Source Sans Pro', sans-serif; max-width: 760px; margin: 2rem auto; padding: 0 1rem; color: #333; }
+  h1 { font-weight: 600; }
+  .meta { color: #666; font-size: 0.9rem; }
+  .meta dt { font-weight: 600; display: inline-block; min-width: 9rem; }
+  .meta dd { display: inline; margin: 0; }
+  .meta div { margin: 0.25rem 0; }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+  th, td { text-align: left; padding: 0.4rem 0.5rem; border-bottom: 1px solid #eee; }
+  th { font-weight: 600; }
+  .centrality { text-align: right; font-variant-numeric: tabular-nums; }
+  .actions { margin-top: 1.5rem; }
+  button.primary { background: #3366cc; color: white; border: 0; padding: 0.7rem 1.5rem; font-size: 1rem; border-radius: 4px; cursor: pointer; }
+  button.primary:hover { background: #2a539b; }
+  .error { background: #fef0f0; border-left: 4px solid #c33; padding: 1rem; margin: 1rem 0; }
+  .copy-box { width: 100%; font-family: monospace; font-size: 0.85rem; padding: 0.5rem; }
+</style>

--- a/app/views/imports/import_error.html.erb
+++ b/app/views/imports/import_error.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Import failed</title>
+  <%= render 'layout_head' %>
+</head>
+<body>
+  <h1>Import failed</h1>
+  <div class="error">
+    <p><%= @import_error %></p>
+  </div>
+
+  <p>You can copy the message below and share it with the AI to ask for a fix:</p>
+  <textarea class="copy-box" rows="3" readonly><%= "handle=#{@handle}\nerror: #{@import_error}" %></textarea>
+
+  <p class="actions">
+    <a href="<%= import_path(handle: @handle) %>">Back to handoff preview</a>
+  </p>
+</body>
+</html>

--- a/app/views/imports/network_error.html.erb
+++ b/app/views/imports/network_error.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Topic Builder unreachable</title>
+  <%= render 'layout_head' %>
+</head>
+<body>
+  <h1>Couldn't reach Topic Builder</h1>
+  <div class="error">
+    <p>Topic Builder might be down — try again in a minute.</p>
+    <p class="meta">Details: <code><%= @network_error %></code></p>
+  </div>
+  <p><a href="<%= import_path(handle: @handle) %>">Try again</a></p>
+</body>
+</html>

--- a/app/views/imports/not_found.html.erb
+++ b/app/views/imports/not_found.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Topic Builder handoff not found</title>
+  <%= render 'layout_head' %>
+</head>
+<body>
+  <h1>Handoff not found</h1>
+  <div class="error">
+    <p>This Topic Builder handoff is unknown or has expired.</p>
+    <p>Ask the AI to call <code>publish_topic</code> again to mint a fresh handle, then open the new link.</p>
+  </div>
+  <p class="meta">Handle: <code><%= @handle %></code></p>
+</body>
+</html>

--- a/app/views/imports/schema_mismatch.html.erb
+++ b/app/views/imports/schema_mismatch.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Topic Builder handoff: schema mismatch</title>
+  <%= render 'layout_head' %>
+</head>
+<body>
+  <h1>Schema version mismatch</h1>
+  <div class="error">
+    <p>This handoff was minted for an unknown schema version
+    (<code><%= @schema_version.inspect %></code>).</p>
+    <p>Update Impact Visualizer or ask Topic Builder to mint a fresh handle.</p>
+  </div>
+  <p class="meta">Handle: <code><%= @handle %></code></p>
+</body>
+</html>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Import from Topic Builder</title>
+  <%= render 'layout_head' %>
+</head>
+<body>
+  <h1>Import from Topic Builder</h1>
+
+  <p>You're about to import a topic curated in
+  <a href="https://topic-builder.wikiedu.org/">Topic Builder</a>.
+  Review the details below, then click <strong>Import topic</strong>.</p>
+
+  <h2><%= @package.dig('config', 'name') %></h2>
+
+  <dl class="meta">
+    <div><dt>Slug:</dt> <dd><code><%= @package.dig('config', 'slug') %></code></dd></div>
+    <div><dt>Wiki:</dt> <dd><%= @package.dig('config', 'wiki') %>.wikipedia.org</dd></div>
+    <div><dt>Editor label:</dt> <dd><%= @package.dig('config', 'editor_label') %></dd></div>
+    <div><dt>Date range:</dt> <dd><%= @package.dig('config', 'start_date') %> &mdash; <%= @package.dig('config', 'end_date') %></dd></div>
+    <div><dt>Timepoint interval:</dt> <dd>every <%= @package.dig('config', 'timepoint_day_interval') %> days</dd></div>
+    <div><dt>Article count:</dt> <dd><%= @package['article_count'] %></dd></div>
+    <div><dt>Source topic:</dt> <dd><%= @package['source_topic'] %></dd></div>
+    <div><dt>Schema version:</dt> <dd><%= @package['schema_version'] %></dd></div>
+    <div><dt>Handle:</dt> <dd><code><%= @package['handle'] %></code></dd></div>
+  </dl>
+
+  <% if @package.dig('config', 'description').present? %>
+    <h3>Description</h3>
+    <p><%= @package.dig('config', 'description') %></p>
+  <% end %>
+
+  <h3>First <%= @first_articles.size %> articles</h3>
+  <table>
+    <thead>
+      <tr><th>Title</th><th class="centrality">Centrality</th></tr>
+    </thead>
+    <tbody>
+      <% @first_articles.each do |a| %>
+        <tr>
+          <td><%= a['title'] %></td>
+          <td class="centrality"><%= a['centrality'].nil? ? '—' : a['centrality'] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= form_with url: import_path(handle: @handle), method: :post, local: true, class: 'actions' do %>
+    <button type="submit" class="primary">Import topic</button>
+  <% end %>
+</body>
+</html>

--- a/app/views/topics/_topic.jbuilder
+++ b/app/views/topics/_topic.jbuilder
@@ -9,7 +9,7 @@ json.extract! topic, :id, :name, :description, :end_date, :slug,
               :users_csv_filename, :articles_csv_url, :articles_csv_filename,
               :timepoint_generate_job_id, :users_import_job_id, :article_import_job_id,
               :timepoints_count, :summaries_count, :tokens_per_word, :convert_tokens_to_words,
-              :classification_ids
+              :classification_ids, :tb_handle
 
 if topic.wiki
   json.wiki do

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,15 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+
+# Load per-developer .env.local (gitignored) and shared .env if present, so
+# things like local PGHOST/PGPORT and VISUALIZER_USER_AGENT can be pinned
+# without requiring shell-export ceremony. First file wins; pre-existing
+# environment variables (e.g. CI's PGHOST) are not overridden.
+require "dotenv"
+Dotenv.load(
+  File.expand_path("../.env.local", __dir__),
+  File.expand_path("../.env", __dir__)
+)
+
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,9 @@ Rails.application.routes.draw do
     resources :classifications, only: [:index]
   end
 
+  get '/imports/:handle', to: 'imports#show', as: :import, constraints: { handle: %r{[^/]+} }
+  post '/imports/:handle', to: 'imports#create', constraints: { handle: %r{[^/]+} }
+
   get '/topics/:slug', to: 'pages#index'
   get '/my-topics', to: 'pages#index'
   get '/my-topics/new', to: 'pages#index'

--- a/db/migrate/20260501000000_add_centrality_to_article_bag_articles.rb
+++ b/db/migrate/20260501000000_add_centrality_to_article_bag_articles.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCentralityToArticleBagArticles < ActiveRecord::Migration[7.0]
+  def change
+    return if column_exists?(:article_bag_articles, :centrality)
+
+    add_column :article_bag_articles, :centrality, :integer
+  end
+end

--- a/db/migrate/20260501000001_add_tb_handle_to_topics.rb
+++ b/db/migrate/20260501000001_add_tb_handle_to_topics.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddTbHandleToTopics < ActiveRecord::Migration[7.0]
+  def change
+    return if column_exists?(:topics, :tb_handle)
+
+    add_column :topics, :tb_handle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_02_000000) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_01_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_02_000000) do
     t.bigint "article_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "centrality"
     t.index ["article_bag_id"], name: "index_article_bag_articles_on_article_bag_id"
     t.index ["article_id"], name: "index_article_bag_articles_on_article_id"
   end
@@ -275,6 +276,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_02_000000) do
     t.float "tokens_per_word", default: 3.25
     t.string "incremental_topic_build_job_id"
     t.string "generate_article_analytics_job_id"
+    t.string "tb_handle"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/article_bag_articles.rb
+++ b/spec/factories/article_bag_articles.rb
@@ -10,6 +10,7 @@ end
 # Table name: article_bag_articles
 #
 #  id             :bigint           not null, primary key
+#  centrality     :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  article_bag_id :bigint           not null

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -26,6 +26,7 @@ end
 #  name                              :string
 #  slug                              :string
 #  start_date                        :datetime
+#  tb_handle                         :string
 #  timepoint_day_interval            :integer          default(7)
 #  tokens_per_word                   :float            default(3.25)
 #  created_at                        :datetime         not null

--- a/spec/models/article_bag_article_spec.rb
+++ b/spec/models/article_bag_article_spec.rb
@@ -12,6 +12,7 @@ end
 # Table name: article_bag_articles
 #
 #  id             :bigint           not null, primary key
+#  centrality     :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  article_bag_id :bigint           not null

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -341,6 +341,7 @@ end
 #  name                              :string
 #  slug                              :string
 #  start_date                        :datetime
+#  tb_handle                         :string
 #  timepoint_day_interval            :integer          default(7)
 #  tokens_per_word                   :float            default(3.25)
 #  created_at                        :datetime         not null

--- a/spec/requests/imports_controller_spec.rb
+++ b/spec/requests/imports_controller_spec.rb
@@ -108,6 +108,10 @@ describe ImportsController do
 
         enqueued = ImportTopicBuilderArticlesJob.jobs.last
         expect(enqueued['args']).to eq([topic.id, handle])
+        # Topic's article_import_job_id matches the enqueued job's jid —
+        # i.e. the column was set before the job was enqueued, so a
+        # fast-worker race can't leave a stale id behind.
+        expect(enqueued['jid']).to eq(topic.article_import_job_id)
       end
 
       it 'shows the unknown-wiki error if IV has no row for the language' do

--- a/spec/requests/imports_controller_spec.rb
+++ b/spec/requests/imports_controller_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ImportsController do
+  let!(:wiki) { Wiki.find_or_create_by!(language: 'en', project: 'wikipedia') }
+  let(:handle) { 'tbp_abc123' }
+  let(:url) { "https://topic-builder.wikiedu.org/packages/#{handle}" }
+  let(:package) do
+    {
+      'handle' => handle,
+      'schema_version' => 1,
+      'config' => {
+        'name' => 'Educational Psychology',
+        'slug' => 'educational-psychology',
+        'description' => 'A topic.',
+        'editor_label' => 'students',
+        'start_date' => '2026-01-15',
+        'end_date' => '2026-05-30',
+        'timepoint_day_interval' => 30,
+        'wiki' => 'en'
+      },
+      'articles' => [
+        { 'title' => 'Achievement gap', 'centrality' => 8 },
+        { 'title' => 'Active learning', 'centrality' => nil }
+      ],
+      'article_count' => 2,
+      'source_topic' => 'educational psychology'
+    }
+  end
+  let!(:admin) { create(:admin_user, email: 'admin@example.com', password: 'password123') }
+
+  describe 'GET /imports/:handle' do
+    context 'when not signed in' do
+      it 'redirects to admin sign-in' do
+        get "/imports/#{handle}"
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+
+    context 'when signed in as admin' do
+      before { sign_in admin }
+
+      it 'renders the preview on a valid 200 from TB' do
+        stub_request(:get, url).to_return(
+          status: 200, body: package.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        get "/imports/#{handle}"
+        expect(response.status).to eq(200)
+        expect(response.body).to include('Educational Psychology')
+        expect(response.body).to include('Achievement gap')
+        expect(response.body).to include('Import topic')
+      end
+
+      it 'renders the not-found page when TB returns 404' do
+        stub_request(:get, url).to_return(status: 404, body: '{"error":"not found"}')
+        get "/imports/#{handle}"
+        expect(response.status).to eq(404)
+        expect(response.body).to include('Handoff not found')
+      end
+
+      it 'renders the schema-mismatch page on unknown schema_version' do
+        stub_request(:get, url).to_return(
+          status: 200, body: package.merge('schema_version' => 2).to_json
+        )
+        get "/imports/#{handle}"
+        expect(response.status).to eq(422)
+        expect(response.body).to include('Schema version mismatch')
+      end
+
+      it 'renders the network-error page on TB 5xx after retry' do
+        stub_request(:get, url).to_return(status: 503, body: '').times(2)
+        get "/imports/#{handle}"
+        expect(response.status).to eq(502)
+        expect(response.body).to include("Couldn't reach Topic Builder")
+      end
+    end
+  end
+
+  describe 'POST /imports/:handle' do
+    context 'when not signed in' do
+      it 'redirects to admin sign-in' do
+        post "/imports/#{handle}"
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+
+    context 'when signed in as admin' do
+      before { sign_in admin }
+
+      it 'creates the topic and redirects to its show page' do
+        stub_request(:get, url).to_return(
+          status: 200, body: package.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+        expect { post "/imports/#{handle}" }
+          .to change(Topic, :count).by(1)
+
+        topic = Topic.last
+        expect(topic.tb_handle).to eq(handle)
+        expect(topic.articles.pluck(:title)).to match_array(['Achievement gap', 'Active learning'])
+        expect(response).to redirect_to("/topics/#{topic.slug}")
+      end
+
+      it 'persists centrality on the article_bag_articles' do
+        stub_request(:get, url).to_return(
+          status: 200, body: package.to_json
+        )
+        post "/imports/#{handle}"
+        topic = Topic.last
+        bag = topic.article_bags.first
+        scores = bag.article_bag_articles.includes(:article).map { |a| [a.article.title, a.centrality] }.to_h
+        expect(scores).to eq('Achievement gap' => 8, 'Active learning' => nil)
+      end
+
+      it 'shows the unknown-wiki error if IV has no row for the language' do
+        package['config']['wiki'] = 'klingon'
+        stub_request(:get, url).to_return(status: 200, body: package.to_json)
+        post "/imports/#{handle}"
+        expect(response.status).to eq(422)
+        expect(response.body).to include('Import failed')
+        expect(response.body).to include('klingon')
+      end
+
+      it 'returns 404 when the package is not found' do
+        stub_request(:get, url).to_return(status: 404, body: '{"error":"not found"}')
+        post "/imports/#{handle}"
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/requests/imports_controller_spec.rb
+++ b/spec/requests/imports_controller_spec.rb
@@ -89,30 +89,25 @@ describe ImportsController do
     context 'when signed in as admin' do
       before { sign_in admin }
 
-      it 'creates the topic and redirects to its show page' do
+      it 'creates the topic, enqueues the article-ingestion job, and redirects by id' do
         stub_request(:get, url).to_return(
           status: 200, body: package.to_json,
           headers: { 'Content-Type' => 'application/json' }
         )
 
-        expect { post "/imports/#{handle}" }
-          .to change(Topic, :count).by(1)
+        expect {
+          post "/imports/#{handle}"
+        }.to change(Topic, :count).by(1)
+          .and change(ImportTopicBuilderArticlesJob.jobs, :size).by(1)
 
         topic = Topic.last
         expect(topic.tb_handle).to eq(handle)
-        expect(topic.articles.pluck(:title)).to match_array(['Achievement gap', 'Active learning'])
-        expect(response).to redirect_to("/topics/#{topic.slug}")
-      end
+        expect(topic.article_import_job_id).to be_present
+        expect(topic.articles).to be_empty # ingestion is async
+        expect(response).to redirect_to("/topics/#{topic.id}")
 
-      it 'persists centrality on the article_bag_articles' do
-        stub_request(:get, url).to_return(
-          status: 200, body: package.to_json
-        )
-        post "/imports/#{handle}"
-        topic = Topic.last
-        bag = topic.article_bags.first
-        scores = bag.article_bag_articles.includes(:article).map { |a| [a.article.title, a.centrality] }.to_h
-        expect(scores).to eq('Achievement gap' => 8, 'Active learning' => nil)
+        enqueued = ImportTopicBuilderArticlesJob.jobs.last
+        expect(enqueued['args']).to eq([topic.id, handle])
       end
 
       it 'shows the unknown-wiki error if IV has no row for the language' do

--- a/spec/services/topic_builder_import_service_spec.rb
+++ b/spec/services/topic_builder_import_service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TopicBuilderImportService do
+  let!(:wiki) { Wiki.find_or_create_by!(language: 'en', project: 'wikipedia') }
+  let(:package) do
+    {
+      'handle' => 'tbp_abc123',
+      'schema_version' => 1,
+      'config' => {
+        'name' => 'Educational Psychology',
+        'slug' => 'educational-psychology',
+        'description' => 'A topic.',
+        'editor_label' => 'students',
+        'start_date' => '2026-01-15',
+        'end_date' => '2026-05-30',
+        'timepoint_day_interval' => 30,
+        'wiki' => 'en'
+      },
+      'articles' => [
+        { 'title' => 'Achievement gap', 'centrality' => 8 },
+        { 'title' => 'Active learning', 'centrality' => nil }
+      ],
+      'article_count' => 2,
+      'source_topic' => 'educational psychology'
+    }
+  end
+
+  describe '#import!' do
+    it 'creates a Topic, ArticleBag, and ArticleBagArticles atomically' do
+      expect {
+        described_class.new(package: package).import!
+      }.to change(Topic, :count).by(1)
+        .and change(ArticleBag, :count).by(1)
+        .and change(Article, :count).by(2)
+        .and change(ArticleBagArticle, :count).by(2)
+    end
+
+    it 'sets topic fields from the package config' do
+      topic = described_class.new(package: package).import!
+      expect(topic).to have_attributes(
+        name: 'Educational Psychology',
+        slug: 'educational-psychology',
+        description: 'A topic.',
+        editor_label: 'students',
+        timepoint_day_interval: 30,
+        display: false,
+        wiki_id: wiki.id,
+        tb_handle: 'tbp_abc123'
+      )
+      expect(topic.start_date.to_date).to eq(Date.new(2026, 1, 15))
+      expect(topic.end_date.to_date).to eq(Date.new(2026, 5, 30))
+    end
+
+    it 'persists centrality scores per article' do
+      topic = described_class.new(package: package).import!
+      bag = topic.article_bags.first
+      bagged = bag.article_bag_articles.includes(:article).index_by { |aba| aba.article.title }
+      expect(bagged.fetch('Achievement gap').centrality).to eq(8)
+      expect(bagged.fetch('Active learning').centrality).to be_nil
+    end
+
+    it 'raises UnknownWikiError when IV has no row for the language' do
+      package['config']['wiki'] = 'klingon'
+      expect {
+        described_class.new(package: package).import!
+      }.to raise_error(TopicBuilderImportService::UnknownWikiError, /klingon/)
+    end
+
+    it 'raises ValidationError and rolls back when a centrality is out of range' do
+      package['articles'] << { 'title' => 'Bogus', 'centrality' => 99 }
+      expect {
+        expect {
+          described_class.new(package: package).import!
+        }.to raise_error(TopicBuilderImportService::ValidationError)
+      }.to change(Topic, :count).by(0)
+        .and change(ArticleBag, :count).by(0)
+        .and change(ArticleBagArticle, :count).by(0)
+    end
+
+    it 'associates the topic with a non-admin topic_editor' do
+      editor = create(:topic_editor)
+      topic = described_class.new(package: package, topic_editor: editor).import!
+      expect(editor.topics).to include(topic)
+    end
+
+    it 'does not associate when topic_editor is an admin (admin posture)' do
+      admin = create(:admin_user, email: 'admin@example.com', password: 'password123')
+      topic = described_class.new(package: package, topic_editor: admin).import!
+      expect(topic.topic_editors).to be_empty
+    end
+  end
+end

--- a/spec/services/topic_builder_import_service_spec.rb
+++ b/spec/services/topic_builder_import_service_spec.rb
@@ -28,13 +28,13 @@ describe TopicBuilderImportService do
   end
 
   describe '#import!' do
-    it 'creates a Topic, ArticleBag, and ArticleBagArticles atomically' do
+    it 'creates a Topic and an empty ArticleBag atomically (articles are imported async)' do
       expect {
         described_class.new(package: package).import!
       }.to change(Topic, :count).by(1)
         .and change(ArticleBag, :count).by(1)
-        .and change(Article, :count).by(2)
-        .and change(ArticleBagArticle, :count).by(2)
+        .and change(Article, :count).by(0)
+        .and change(ArticleBagArticle, :count).by(0)
     end
 
     it 'sets topic fields from the package config' do
@@ -53,30 +53,11 @@ describe TopicBuilderImportService do
       expect(topic.end_date.to_date).to eq(Date.new(2026, 5, 30))
     end
 
-    it 'persists centrality scores per article' do
-      topic = described_class.new(package: package).import!
-      bag = topic.article_bags.first
-      bagged = bag.article_bag_articles.includes(:article).index_by { |aba| aba.article.title }
-      expect(bagged.fetch('Achievement gap').centrality).to eq(8)
-      expect(bagged.fetch('Active learning').centrality).to be_nil
-    end
-
     it 'raises UnknownWikiError when IV has no row for the language' do
       package['config']['wiki'] = 'klingon'
       expect {
         described_class.new(package: package).import!
       }.to raise_error(TopicBuilderImportService::UnknownWikiError, /klingon/)
-    end
-
-    it 'raises ValidationError and rolls back when a centrality is out of range' do
-      package['articles'] << { 'title' => 'Bogus', 'centrality' => 99 }
-      expect {
-        expect {
-          described_class.new(package: package).import!
-        }.to raise_error(TopicBuilderImportService::ValidationError)
-      }.to change(Topic, :count).by(0)
-        .and change(ArticleBag, :count).by(0)
-        .and change(ArticleBagArticle, :count).by(0)
     end
 
     it 'associates the topic with a non-admin topic_editor' do

--- a/spec/services/topic_builder_package_service_spec.rb
+++ b/spec/services/topic_builder_package_service_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TopicBuilderPackageService do
+  let(:handle) { 'tbp_abc123' }
+  let(:url) { "https://topic-builder.wikiedu.org/packages/#{handle}" }
+  let(:package) do
+    {
+      'handle' => handle,
+      'schema_version' => 1,
+      'config' => { 'name' => 'X', 'wiki' => 'en' },
+      'articles' => [],
+      'article_count' => 0,
+      'source_topic' => 'x'
+    }
+  end
+
+  describe '.valid_handle?' do
+    it 'accepts tbp_-prefixed strings' do
+      expect(described_class.valid_handle?('tbp_abc')).to eq(true)
+    end
+
+    it 'rejects other strings' do
+      expect(described_class.valid_handle?('abc')).to eq(false)
+      expect(described_class.valid_handle?(nil)).to eq(false)
+    end
+  end
+
+  describe '.fetch' do
+    it 'returns the parsed JSON on 200' do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: package.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+      expect(described_class.fetch(handle)).to eq(package)
+    end
+
+    it 'raises NotFound on 404' do
+      stub_request(:get, url).to_return(status: 404, body: '{"error":"not found"}')
+      expect { described_class.fetch(handle) }
+        .to raise_error(TopicBuilderPackageService::NotFound)
+    end
+
+    it 'raises NotFound when handle does not start with tbp_' do
+      expect { described_class.fetch('garbage') }
+        .to raise_error(TopicBuilderPackageService::NotFound)
+    end
+
+    it 'retries once on 5xx, then succeeds' do
+      stub_request(:get, url)
+        .to_return(status: 503, body: '')
+        .then.to_return(status: 200, body: package.to_json)
+      expect(described_class.fetch(handle)).to eq(package)
+    end
+
+    it 'raises NetworkError after retry still fails on 5xx' do
+      stub_request(:get, url).to_return(status: 503, body: '').times(2)
+      expect { described_class.fetch(handle) }
+        .to raise_error(TopicBuilderPackageService::NetworkError)
+    end
+
+    it 'raises NetworkError on parse failure' do
+      stub_request(:get, url).to_return(status: 200, body: 'not json')
+      expect { described_class.fetch(handle) }
+        .to raise_error(TopicBuilderPackageService::NetworkError, /invalid JSON/)
+    end
+  end
+
+  describe '.assert_supported_schema!' do
+    it 'no-ops on schema_version=1' do
+      expect { described_class.assert_supported_schema!('schema_version' => 1) }.not_to raise_error
+    end
+
+    it 'raises on other versions' do
+      expect { described_class.assert_supported_schema!('schema_version' => 2) }
+        .to raise_error(TopicBuilderPackageService::SchemaVersionError)
+    end
+  end
+end

--- a/spec/sidekiq/import_topic_builder_articles_job_spec.rb
+++ b/spec/sidekiq/import_topic_builder_articles_job_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe ImportTopicBuilderArticlesJob, type: :job do
     }.not_to change { bag.reload.article_bag_articles.count }
   end
 
+  it 'clears article_import_job_id when all retries are exhausted' do
+    topic.update(article_import_job_id: 'fake-jid')
+    described_class.sidekiq_retries_exhausted_block.call(
+      { 'args' => [topic.id, handle] }, RuntimeError.new('TB unreachable')
+    )
+    expect(topic.reload.article_import_job_id).to be_nil
+  end
+
   it 'auto-chains article analytics + incremental topic build on success' do
     expect {
       described_class.new.perform(topic.id, handle)

--- a/spec/sidekiq/import_topic_builder_articles_job_spec.rb
+++ b/spec/sidekiq/import_topic_builder_articles_job_spec.rb
@@ -54,4 +54,16 @@ RSpec.describe ImportTopicBuilderArticlesJob, type: :job do
       described_class.new.perform(topic.id, handle)
     }.not_to change { bag.reload.article_bag_articles.count }
   end
+
+  it 'auto-chains article analytics + incremental topic build on success' do
+    expect {
+      described_class.new.perform(topic.id, handle)
+    }.to change(GenerateArticleAnalyticsJob.jobs, :size).by(1)
+      .and change(IncrementalTopicBuildJob.jobs, :size).by(1)
+
+    inc = IncrementalTopicBuildJob.jobs.last['args']
+    # (topic_id, stage, queue_next_stage, force_updates) — start at the
+    # first stage and chain through all four.
+    expect(inc).to eq([topic.id, 'classify', true, false])
+  end
 end

--- a/spec/sidekiq/import_topic_builder_articles_job_spec.rb
+++ b/spec/sidekiq/import_topic_builder_articles_job_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportTopicBuilderArticlesJob, type: :job do
+  let!(:wiki) { Wiki.find_or_create_by!(language: 'en', project: 'wikipedia') }
+  let(:handle) { 'tbp_abc123' }
+  let(:url) { "https://topic-builder.wikiedu.org/packages/#{handle}" }
+  let(:topic) { create(:topic, wiki: wiki, tb_handle: handle) }
+  let(:bag) { topic.active_article_bag }
+  let(:package) do
+    {
+      'handle' => handle,
+      'schema_version' => 1,
+      'config' => { 'name' => topic.name, 'wiki' => 'en' },
+      'articles' => [
+        { 'title' => 'Achievement gap', 'centrality' => 8 },
+        { 'title' => 'Active learning', 'centrality' => nil }
+      ]
+    }
+  end
+
+  before do
+    bag # force the empty bag into existence (the factory creates one)
+    stub_request(:get, url).to_return(
+      status: 200, body: package.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+  end
+
+  it 'fetches the package and populates the bag' do
+    expect {
+      described_class.new.perform(topic.id, handle)
+    }.to change { bag.reload.article_bag_articles.count }.from(0).to(2)
+      .and change(Article, :count).by(2)
+  end
+
+  it 'persists centrality scores per article' do
+    described_class.new.perform(topic.id, handle)
+    scores = bag.reload.article_bag_articles.includes(:article)
+                .map { |a| [a.article.title, a.centrality] }.to_h
+    expect(scores).to eq('Achievement gap' => 8, 'Active learning' => nil)
+  end
+
+  it 'clears article_import_job_id when finished' do
+    topic.update(article_import_job_id: 'fake-job-id')
+    described_class.new.perform(topic.id, handle)
+    expect(topic.reload.article_import_job_id).to be_nil
+  end
+
+  it 'is idempotent on retry — does not duplicate ArticleBagArticles' do
+    described_class.new.perform(topic.id, handle)
+    expect {
+      described_class.new.perform(topic.id, handle)
+    }.not_to change { bag.reload.article_bag_articles.count }
+  end
+end


### PR DESCRIPTION
## Summary

Implements the IV-side surface area of the Topic Builder → Impact
Visualizer handoff specified in
[`topic-builder/docs/backlog/impact-visualizer.md`][spec]. The TB side
(`iv_packages` table, `prepare_iv_handoff` / `publish_topic` MCP
tools, public `GET /packages/<handle>` endpoint) shipped 2026-05-01;
this PR is the greenfield IV side that consumes those packages.

## End-to-end flow

1. User finishes curating a topic in a Topic Builder conversation.
2. AI calls `publish_topic`, gets a handle, and hands the user a URL
   like `https://impact-visualizer.wmcloud.org/imports/tbp_<handle>`.
3. User (signed in to IV as admin) opens the URL → sees a
   server-rendered preview: name, dates, article count, first ~10
   articles with centrality, source topic, schema version. One
   button: **Import topic**.
4. User clicks Import. IV server-side re-fetches the package from TB,
   validates `schema_version == 1`, resolves `wiki_id` from IV's own
   `wikis` table, and creates `Topic` + (empty) `ArticleBag` in a
   transaction. An `ImportTopicBuilderArticlesJob` is enqueued to
   populate `ArticleBagArticles` row-by-row in the background.
5. User is redirected immediately to `/topics/<id>` while ingestion
   continues; the existing TopicAction progress-bar UI lights up via
   `Sidekiq::Status`.

## Screenshots

**1. `/imports/<handle>` — preview page**

![import preview](https://raw.githubusercontent.com/WikiEducationFoundation/impact-visualizer/pr-screenshots/TopicBuilderIntegration/screenshots/01-import-preview.png)

**2. Topic detail page after import** — streamlined TB-topic UI: no
Users panel, no CSV upload form, Generate Timepoints / Generate
Article Analytics available with 0 users.

![topic detail](https://raw.githubusercontent.com/WikiEducationFoundation/impact-visualizer/pr-screenshots/TopicBuilderIntegration/screenshots/03-topic-detail-tb-imported.png)

**3. `/imports/<bad-handle>` — handoff not found**

![not found](https://raw.githubusercontent.com/WikiEducationFoundation/impact-visualizer/pr-screenshots/TopicBuilderIntegration/screenshots/02-import-not-found.png)

## What landed

### Routes / controller / views

- `GET  /imports/:handle` — preview page (admin-gated)
- `POST /imports/:handle` — transactional import (admin-gated)
- `ImportsController` dispatches errors to dedicated views per failure
  mode: `not_found` (TB 404), `schema_mismatch` (unknown
  `schema_version`), `network_error` (TB 5xx after retry),
  `import_error` (validation / unknown wiki). All four pages share a
  small inline-styled layout (no `application.html.erb` yet in this
  Rails-API-mode app).

### Services

- **`TopicBuilderPackageService`** — fetches the package over HTTPS
  (20s timeout, retries once on 5xx), rejects handles missing the
  `tbp_` prefix, asserts `schema_version == 1`. Base URL overridable
  via `TOPIC_BUILDER_BASE_URL`.
- **`TopicBuilderImportService`** — resolves wiki by `language`
  against IV's own `wikis` table (TB's `wiki_id` is advisory and
  ignored, per spec); creates the `Topic` and an empty `ArticleBag`
  in a single transaction; raises `UnknownWikiError` /
  `ValidationError` so the controller can render an actionable page.

### Sidekiq job

- **`ImportTopicBuilderArticlesJob`** — re-fetches the package, then
  walks `articles[]` and runs `Article.find_or_create_by!` +
  `ArticleBagArticle.find_or_create_by!` for each entry, populating
  `centrality`. Uses `Sidekiq::Status::Worker` so the existing
  progress-bar UI lights up; idempotent on retry (dedupes on
  bag+article); clears `topic.article_import_job_id` on completion.
  Sidekiq's default 3-retry policy is therefore safe.

### Schema (two new migrations)

- `article_bag_articles.centrality` — nullable integer, validated
  1..10. Required day one even though IV's UI doesn't surface
  centrality yet; TB is already emitting it and re-imports must
  persist cleanly.
- `topics.tb_handle` — nullable string, records which TB handle
  minted the topic. Useful for audit and reserves the linkage shape
  for the post-v1 atomic-edits feature in the spec.

### Frontend (streamlined topic-detail UI for TB topics)

The TopicActions panel on `/topics/:id` previously assumed every topic
was CSV-driven: it required a users CSV before showing the Articles
or Article Analytics panels, and a `users_csv_filename` to even
attempt timepoint generation. For a TB-imported topic that's wrong on
both axes — articles arrive via the package, and TB doesn't supply
users yet.

- `_topic.jbuilder` + `Topic` TS type now expose `tb_handle`.
- `topic-action.component.tsx` — Articles `isReady` is now
  `articles_csv_filename || articles_count > 0 || tb_handle`, so TB
  topics never show the CSV upload form.
- `topic-actions.component.tsx`:
  - Drops the legacy `users_csv_filename` proceed gate that hid the
    Articles + Article Analytics panels.
  - Omits the Users panel entirely for TB topics (chosen over a
    "coming soon" placeholder so the UI doesn't carry a vestigial
    dead panel; the moment TB starts emitting users, we replace the
    panel rather than retiring an in-place upload form).
  - Lets `incremental_topic_build` run with 0 users for TB topics —
    `TopicService#incremental_topic_build` already only requires
    articles; the `user_count > 0` UI gate was UI-only and pre-dated
    TB.
  - Skips the `users_import_status` check for TB topics so a stale
    job_id from a different code path can't keep blocking timepoint
    generation.

CSV-driven topics see no behavior change: the `user_count > 0` and
`users_import_status` gates are still enforced when `tb_handle` is
absent.

## Locked decisions inherited from the spec

For the record, these were settled in the 2026-05-01 plan and shaped
the controller/view design:

- **Manual handoff via clickable link.** No cross-server auth
  between TB and IV; the user clicks the link and IV does its own
  admin session check.
- **Path-segment URL** `/imports/tbp_<handle>`, not query-string.
- **`/packages/<handle>` payload is config + article titles inline.**
  No CSV-URL indirection. Centrality rides per-article.
- **Frozen at publish time** on the TB side. Re-publish mints a new
  handle; this PR doesn't try to support post-import edits.
- **Atomic post-import edits are out of scope for v1** but the
  `tb_handle` column reserves the linkage shape for them.

## Testing

```
346 examples, 0 failures
```

Specs added:

- `spec/services/topic_builder_package_service_spec.rb` — 200, 404,
  5xx-retry, prefix rejection, schema-version assertion, JSON parse
  error.
- `spec/services/topic_builder_import_service_spec.rb` — happy path,
  field round-trip, unknown-wiki rollback, editor association.
- `spec/sidekiq/import_topic_builder_articles_job_spec.rb` —
  fetch+populate, centrality persistence, `article_import_job_id`
  clearing on success, idempotent re-runs.
- `spec/requests/imports_controller_spec.rb` — auth gating, all four
  error rendering paths, POST → job enqueue → redirect-by-id.

## Manual verification

Tested against the live `topic-builder.wikiedu.org` with a real
6562-article climate-change package
(`tbp_5QXvEEbdl_EjfG5_ZGykaw`):

- Preview rendered correctly (name, dates, first 10 articles with
  centrality, full description, Import button).
- POST returned an instant redirect to `/topics/<id>` while the
  Sidekiq job ingested 6562 articles in the background.
- 404 page renders for an unknown handle.
- Topic detail page shows the streamlined TB UI (no Users panel, no
  CSV upload form, Generate Timepoints / Generate Article Analytics
  available with 0 users).

## Bonus commits on this branch

- **`62a2ba7` boot.rb dotenv loader.** Local-dev only — `.env.local`
  / `.env` now load before Rails initializes (first file wins; CI's
  pre-set env is unaffected). Came up while debugging local Postgres
  connectivity; stuck around because it's strictly an improvement.
- **`d658e2d` skip users_import_status check for TB topics.** Caught
  while taking the manual-verification screenshots: a stale
  `users_import_job_id === "queued"` from prior dev-DB pollution was
  blocking the Generate Timepoints button. The fix is correct
  regardless of the dev-DB pollution — TB topics shouldn't be gated
  on users-import status they never run.

## Out of scope (deferred to follow-ups)

- **Atomic edits** (`patch_iv_topic` MCP tool + IV-side
  `PATCH /api/v1/topics/<slug>/article_bag`). Reserved in shape via
  `topics.tb_handle`; not built. Re-publishing from TB is the v1
  fallback for "user wants to refine after import."
- **Schema version bump path.** v1 hard-fails on
  `schema_version != 1`. When TB bumps to 2, IV updates first or TB
  ships behind a flag.
- **Authenticated-editor (non-admin) imports.** v1 is admin-only,
  matching IV's existing console-only import posture.
- **Background-job split for very-large topics.** Spec called this
  out at >500 articles, but ingestion is now async for *all* TB
  topics (per the "feels quick to the user" preference), so the 500
  cutoff doesn't apply.
- **TB → IV user list.** TB doesn't emit users yet; the UI hides the
  Users panel for TB topics rather than carrying a placeholder.

[spec]: https://github.com/WikiEducationFoundation/topic-builder/blob/main/docs/backlog/impact-visualizer.md
