### PR TITLE
Parallelize GenerateArticleAnalyticsJob; sequential chain to timepoint build

### DIFF
--- a/app/services/article_stats_service.rb
+++ b/app/services/article_stats_service.rb
@@ -182,9 +182,10 @@ class ArticleStatsService
 
     pageid = page_info['pageid']
     revision = @wiki_action_api.get_page_revision_at_timestamp(pageid:, timestamp: date)
-    Rails.logger.info("[ArticleStatsService] Final talk page size: #{revision['size']}")
+    return nil unless revision
 
-    revision ? revision['size'] : nil
+    Rails.logger.info("[ArticleStatsService] Final talk page size: #{revision['size']}")
+    revision['size']
   rescue StandardError => e
     Rails.logger.error("[ArticleStatsService] Error fetching talk page size for #{talk_title}: #{e.message}")
     nil

--- a/app/sidekiq/generate_article_analytics_job.rb
+++ b/app/sidekiq/generate_article_analytics_job.rb
@@ -41,72 +41,91 @@ class GenerateArticleAnalyticsJob
     article_stats_service = ArticleStatsService.new(wiki)
     progress_mutex = Mutex.new
     skipped_mutex = Mutex.new
+    errored_mutex = Mutex.new
     done = 0
     skipped_count = 0
+    errored_count = 0
 
     Parallel.each(articles, in_threads: THREADS_COUNT) do |article|
       ActiveRecord::Base.connection_pool.with_connection do
-        # skip if the page doesn't exist
-        article_stats_service.update_details_for_article(article:)
-        if article.reload.missing
-          Rails.logger.info("[GenerateArticleAnalyticsJob] Article not found: #{article.title}")
-          skipped_mutex.synchronize { skipped_count += 1; store(skipped: skipped_count) }
-          progress_mutex.synchronize { done += 1; at(done, "Not found: #{article.title}") }
-          next
+        # Per-article exception isolation. Without this, a single
+        # article's transient network blip (e.g., a Net::OpenTimeout
+        # to the pageviews cluster that escapes the per-API retry
+        # loops) propagates out of the Parallel.each block, fails the
+        # whole batch, and Sidekiq auto-retries the entire job from
+        # scratch — losing tens of minutes of API work each time.
+        # Catch StandardError per article, log it, increment a
+        # separate "errored" counter, and move on.
+        begin
+          # skip if the page doesn't exist
+          article_stats_service.update_details_for_article(article:)
+          if article.reload.missing
+            Rails.logger.info("[GenerateArticleAnalyticsJob] Article not found: #{article.title}")
+            skipped_mutex.synchronize { skipped_count += 1; store(skipped: skipped_count) }
+            progress_mutex.synchronize { done += 1; at(done, "Not found: #{article.title}") }
+            next
+          end
+
+          average_views = article_stats_service.get_average_daily_views(
+            article: article.title,
+            start_year: start_date.year,
+            end_year: end_date.year,
+            start_month: start_date.month,
+            start_day: start_date.day,
+            end_month: end_date.month,
+            end_day: end_date.day
+          )
+
+          prev_average_views = article_stats_service.get_average_daily_views(
+            article: article.title,
+            start_year: prev_start_date.year,
+            end_year: prev_end_date.year,
+            start_month: prev_start_date.month,
+            start_day: prev_start_date.day,
+            end_month: prev_end_date.month,
+            end_day: prev_end_date.day
+          )
+
+          topic_article_analytic = TopicArticleAnalytic.find_or_initialize_by(
+            topic:,
+            article:
+          )
+
+          topic_article_analytic.update!(
+            average_daily_views: average_views.round,
+            prev_average_daily_views: prev_average_views&.round,
+            publication_date: article.first_revision_at&.to_date,
+            linguistic_versions_count: fetch_linguistic_versions_count(article_stats_service:,
+                                                                       article:),
+            images_count: fetch_images_count(article_stats_service:, article:),
+            warning_tags_count: fetch_warning_tags_count(article_stats_service:, article:),
+            number_of_editors: fetch_number_of_editors(article_stats_service:, article:),
+            article_size: fetch_article_size(article_stats_service:, article:, date: end_date),
+            prev_article_size: fetch_article_size(article_stats_service:, article:,
+                                                  date: prev_end_date),
+            talk_size: fetch_talk_size(article_stats_service:, article:, date: end_date),
+            prev_talk_size: fetch_talk_size(article_stats_service:, article:, date: prev_end_date),
+            lead_section_size: fetch_lead_section_size(article_stats_service:, article:,
+                                                       date: end_date),
+            assessment_grade: fetch_assessment_grade(article_stats_service:, article:),
+            article_protections: fetch_article_protections(article_stats_service:, article:),
+            incoming_links_count: fetch_incoming_links_count(article_stats_service:, article:)
+          )
+
+          Rails.logger.info("[GenerateArticleAnalyticsJob] Saved analytics for #{article.title} - average_views: #{average_views.round}, prev_average_views: #{prev_average_views&.round}, article_size: #{topic_article_analytic.article_size}, prev_article_size: #{topic_article_analytic.prev_article_size}, talk_size: #{topic_article_analytic.talk_size}, prev_talk_size: #{topic_article_analytic.prev_talk_size}, lead_section_size: #{topic_article_analytic.lead_section_size}")
+
+          progress_mutex.synchronize { done += 1; at(done, "Processed #{article.title}") }
+        rescue StandardError => e
+          Rails.logger.error(
+            "[GenerateArticleAnalyticsJob] Skipping #{article.title} due to #{e.class}: #{e.message}"
+          )
+          errored_mutex.synchronize { errored_count += 1; store(errored: errored_count) }
+          progress_mutex.synchronize { done += 1; at(done, "Errored: #{article.title}") }
         end
-
-        average_views = article_stats_service.get_average_daily_views(
-          article: article.title,
-          start_year: start_date.year,
-          end_year: end_date.year,
-          start_month: start_date.month,
-          start_day: start_date.day,
-          end_month: end_date.month,
-          end_day: end_date.day
-        )
-
-        prev_average_views = article_stats_service.get_average_daily_views(
-          article: article.title,
-          start_year: prev_start_date.year,
-          end_year: prev_end_date.year,
-          start_month: prev_start_date.month,
-          start_day: prev_start_date.day,
-          end_month: prev_end_date.month,
-          end_day: prev_end_date.day
-        )
-
-        topic_article_analytic = TopicArticleAnalytic.find_or_initialize_by(
-          topic:,
-          article:
-        )
-
-        topic_article_analytic.update!(
-          average_daily_views: average_views.round,
-          prev_average_daily_views: prev_average_views&.round,
-          publication_date: article.first_revision_at&.to_date,
-          linguistic_versions_count: fetch_linguistic_versions_count(article_stats_service:,
-                                                                     article:),
-          images_count: fetch_images_count(article_stats_service:, article:),
-          warning_tags_count: fetch_warning_tags_count(article_stats_service:, article:),
-          number_of_editors: fetch_number_of_editors(article_stats_service:, article:),
-          article_size: fetch_article_size(article_stats_service:, article:, date: end_date),
-          prev_article_size: fetch_article_size(article_stats_service:, article:,
-                                                date: prev_end_date),
-          talk_size: fetch_talk_size(article_stats_service:, article:, date: end_date),
-          prev_talk_size: fetch_talk_size(article_stats_service:, article:, date: prev_end_date),
-          lead_section_size: fetch_lead_section_size(article_stats_service:, article:,
-                                                     date: end_date),
-          assessment_grade: fetch_assessment_grade(article_stats_service:, article:),
-          article_protections: fetch_article_protections(article_stats_service:, article:),
-          incoming_links_count: fetch_incoming_links_count(article_stats_service:, article:)
-        )
-
-        Rails.logger.info("[GenerateArticleAnalyticsJob] Saved analytics for #{article.title} - average_views: #{average_views.round}, prev_average_views: #{prev_average_views&.round}, article_size: #{topic_article_analytic.article_size}, prev_article_size: #{topic_article_analytic.prev_article_size}, talk_size: #{topic_article_analytic.talk_size}, prev_talk_size: #{topic_article_analytic.prev_talk_size}, lead_section_size: #{topic_article_analytic.lead_section_size}")
-
-        progress_mutex.synchronize { done += 1; at(done, "Processed #{article.title}") }
       end
     end
 
+    Rails.logger.info("[GenerateArticleAnalyticsJob] complete. processed=#{done}, skipped(missing)=#{skipped_count}, errored(transient)=#{errored_count}")
     topic.reload.update(generate_article_analytics_job_id: nil)
     chain_incremental_topic_build!(topic)
   end

--- a/app/sidekiq/generate_article_analytics_job.rb
+++ b/app/sidekiq/generate_article_analytics_job.rb
@@ -5,6 +5,15 @@ class GenerateArticleAnalyticsJob
   include Sidekiq::Status::Worker
   sidekiq_options queue: 'article_analytics'
 
+  # Tuned to half the timepoint-service thread count. Phase 2 makes ~16
+  # external calls per article (vs ~4 per article-timestamp pair in the
+  # timepoint phases), so each thread here generates roughly 4× the
+  # request density. 5 threads keeps the peak burst comparable to the
+  # 10-thread timepoint phases. Per-request 429 retry-with-backoff in
+  # WikiActionApi / WikiRestApi / WikimediaPageviewsApi catches the
+  # rest.
+  THREADS_COUNT = 5
+
   def perform(topic_id)
     @expiration = 60 * 60 * 24 * 7
 
@@ -13,7 +22,11 @@ class GenerateArticleAnalyticsJob
     return unless wiki
 
     articles = topic.active_article_bag.articles
-    return if articles.empty?
+    if articles.empty?
+      topic.reload.update(generate_article_analytics_job_id: nil)
+      chain_incremental_topic_build!(topic)
+      return
+    end
 
     total(articles.count)
     at(0, 'Starting article analytics generation')
@@ -26,73 +39,76 @@ class GenerateArticleAnalyticsJob
     prev_start_date = start_date.prev_year
 
     article_stats_service = ArticleStatsService.new(wiki)
+    progress_mutex = Mutex.new
+    skipped_mutex = Mutex.new
+    done = 0
+    skipped_count = 0
 
-    articles.each_with_index do |article, index|
-      at(index, "Fetching \"#{article.title}\"")
-      Rails.logger.info("[GenerateArticleAnalyticsJob] Fetching average daily views for #{article.title} between #{start_date} and #{end_date}")
+    Parallel.each(articles, in_threads: THREADS_COUNT) do |article|
+      ActiveRecord::Base.connection_pool.with_connection do
+        # skip if the page doesn't exist
+        article_stats_service.update_details_for_article(article:)
+        if article.reload.missing
+          Rails.logger.info("[GenerateArticleAnalyticsJob] Article not found: #{article.title}")
+          skipped_mutex.synchronize { skipped_count += 1; store(skipped: skipped_count) }
+          progress_mutex.synchronize { done += 1; at(done, "Not found: #{article.title}") }
+          next
+        end
 
-      # skip if the page doesn't exist
-      article_stats_service.update_details_for_article(article:)
-      if article.reload.missing
-        Rails.logger.info("[GenerateArticleAnalyticsJob] Article not found: #{article.title}")
-        current_skipped = (Sidekiq::Status::get(@jid, :skipped) || '0').to_i
-        store(skipped: current_skipped + 1)
-        at(index + 1, "Not found: #{article.title}")
-        next
+        average_views = article_stats_service.get_average_daily_views(
+          article: article.title,
+          start_year: start_date.year,
+          end_year: end_date.year,
+          start_month: start_date.month,
+          start_day: start_date.day,
+          end_month: end_date.month,
+          end_day: end_date.day
+        )
+
+        prev_average_views = article_stats_service.get_average_daily_views(
+          article: article.title,
+          start_year: prev_start_date.year,
+          end_year: prev_end_date.year,
+          start_month: prev_start_date.month,
+          start_day: prev_start_date.day,
+          end_month: prev_end_date.month,
+          end_day: prev_end_date.day
+        )
+
+        topic_article_analytic = TopicArticleAnalytic.find_or_initialize_by(
+          topic:,
+          article:
+        )
+
+        topic_article_analytic.update!(
+          average_daily_views: average_views.round,
+          prev_average_daily_views: prev_average_views&.round,
+          publication_date: article.first_revision_at&.to_date,
+          linguistic_versions_count: fetch_linguistic_versions_count(article_stats_service:,
+                                                                     article:),
+          images_count: fetch_images_count(article_stats_service:, article:),
+          warning_tags_count: fetch_warning_tags_count(article_stats_service:, article:),
+          number_of_editors: fetch_number_of_editors(article_stats_service:, article:),
+          article_size: fetch_article_size(article_stats_service:, article:, date: end_date),
+          prev_article_size: fetch_article_size(article_stats_service:, article:,
+                                                date: prev_end_date),
+          talk_size: fetch_talk_size(article_stats_service:, article:, date: end_date),
+          prev_talk_size: fetch_talk_size(article_stats_service:, article:, date: prev_end_date),
+          lead_section_size: fetch_lead_section_size(article_stats_service:, article:,
+                                                     date: end_date),
+          assessment_grade: fetch_assessment_grade(article_stats_service:, article:),
+          article_protections: fetch_article_protections(article_stats_service:, article:),
+          incoming_links_count: fetch_incoming_links_count(article_stats_service:, article:)
+        )
+
+        Rails.logger.info("[GenerateArticleAnalyticsJob] Saved analytics for #{article.title} - average_views: #{average_views.round}, prev_average_views: #{prev_average_views&.round}, article_size: #{topic_article_analytic.article_size}, prev_article_size: #{topic_article_analytic.prev_article_size}, talk_size: #{topic_article_analytic.talk_size}, prev_talk_size: #{topic_article_analytic.prev_talk_size}, lead_section_size: #{topic_article_analytic.lead_section_size}")
+
+        progress_mutex.synchronize { done += 1; at(done, "Processed #{article.title}") }
       end
-
-      average_views = article_stats_service.get_average_daily_views(
-        article: article.title,
-        start_year: start_date.year,
-        end_year: end_date.year,
-        start_month: start_date.month,
-        start_day: start_date.day,
-        end_month: end_date.month,
-        end_day: end_date.day
-      )
-
-      prev_average_views = article_stats_service.get_average_daily_views(
-        article: article.title,
-        start_year: prev_start_date.year,
-        end_year: prev_end_date.year,
-        start_month: prev_start_date.month,
-        start_day: prev_start_date.day,
-        end_month: prev_end_date.month,
-        end_day: prev_end_date.day
-      )
-
-      topic_article_analytic = TopicArticleAnalytic.find_or_initialize_by(
-        topic:,
-        article:
-      )
-
-      topic_article_analytic.update!(
-        average_daily_views: average_views.round,
-        prev_average_daily_views: prev_average_views&.round,
-        publication_date: article.first_revision_at&.to_date,
-        linguistic_versions_count: fetch_linguistic_versions_count(article_stats_service:,
-                                                                   article:),
-        images_count: fetch_images_count(article_stats_service:, article:),
-        warning_tags_count: fetch_warning_tags_count(article_stats_service:, article:),
-        number_of_editors: fetch_number_of_editors(article_stats_service:, article:),
-        article_size: fetch_article_size(article_stats_service:, article:, date: end_date),
-        prev_article_size: fetch_article_size(article_stats_service:, article:,
-                                              date: prev_end_date),
-        talk_size: fetch_talk_size(article_stats_service:, article:, date: end_date),
-        prev_talk_size: fetch_talk_size(article_stats_service:, article:, date: prev_end_date),
-        lead_section_size: fetch_lead_section_size(article_stats_service:, article:,
-                                                   date: end_date),
-        assessment_grade: fetch_assessment_grade(article_stats_service:, article:),
-        article_protections: fetch_article_protections(article_stats_service:, article:),
-        incoming_links_count: fetch_incoming_links_count(article_stats_service:, article:)
-      )
-
-      Rails.logger.info("[GenerateArticleAnalyticsJob] Saved analytics for #{article.title} - average_views: #{average_views.round}, prev_average_views: #{prev_average_views&.round}, article_size: #{topic_article_analytic.article_size}, prev_article_size: #{topic_article_analytic.prev_article_size}, talk_size: #{topic_article_analytic.talk_size}, prev_talk_size: #{topic_article_analytic.prev_talk_size}, lead_section_size: #{topic_article_analytic.lead_section_size}")
-
-      at(index + 1, "Processed #{article.title}")
     end
 
     topic.reload.update(generate_article_analytics_job_id: nil)
+    chain_incremental_topic_build!(topic)
   end
 
   def expiration
@@ -100,6 +116,17 @@ class GenerateArticleAnalyticsJob
   end
 
   private
+
+  # The TB handoff is a one-click flow: ingest → analytics → timepoint
+  # build, all auto-chained. For CSV-driven topics the user still
+  # drives each step manually from the topic-detail page, so don't
+  # auto-chain there.
+  def chain_incremental_topic_build!(topic)
+    return unless topic.tb_handle.present?
+    return if topic.incremental_topic_build_job_id.present?
+
+    topic.queue_incremental_topic_build(queue_next_stage: true, force_updates: false)
+  end
 
   def fetch_article_size(article_stats_service:, article:, date:)
     Rails.logger.info("[GenerateArticleAnalyticsJob] Fetching article size for #{article.title} at #{date}")

--- a/app/sidekiq/generate_article_analytics_job.rb
+++ b/app/sidekiq/generate_article_analytics_job.rb
@@ -5,14 +5,14 @@ class GenerateArticleAnalyticsJob
   include Sidekiq::Status::Worker
   sidekiq_options queue: 'article_analytics'
 
-  # Tuned to half the timepoint-service thread count. Phase 2 makes ~16
-  # external calls per article (vs ~4 per article-timestamp pair in the
-  # timepoint phases), so each thread here generates roughly 4× the
-  # request density. 5 threads keeps the peak burst comparable to the
-  # 10-thread timepoint phases. Per-request 429 retry-with-backoff in
-  # WikiActionApi / WikiRestApi / WikimediaPageviewsApi catches the
-  # rest.
-  THREADS_COUNT = 5
+  # Empirically tuned: 5 threads × ~16 calls/article saturates
+  # Wikipedia's per-IP bucket within seconds — a 6562-article test run
+  # generated 44 `429 Too Many Requests` events in the first 3
+  # minutes, with throughput throttled to ~17 articles/min. 3 threads
+  # holds steady-state below the bucket-refill rate so the retry
+  # handler is the exception, not the rule. Per-request retry with
+  # Retry-After + 0–3 s jitter still catches the occasional burst.
+  THREADS_COUNT = 3
 
   def perform(topic_id)
     @expiration = 60 * 60 * 24 * 7

--- a/app/sidekiq/import_topic_builder_articles_job.rb
+++ b/app/sidekiq/import_topic_builder_articles_job.rb
@@ -42,11 +42,14 @@ class ImportTopicBuilderArticlesJob
     # The TB handoff is meant to be a one-click flow: after the user
     # clicks Import, they should land on the topic page and watch all
     # the data populate without further intervention. Kick off article
-    # analytics and the full incremental timepoint build pipeline in
-    # parallel; both jobs lazily populate per-article details on the
-    # fly when they encounter an article without them.
+    # analytics; that job, on completion, will queue the timepoint
+    # build pipeline. The two used to run in parallel, but the
+    # combined burst (5 analytics threads + 10 timepoint threads
+    # against enwiki) caused enough 429s that downstream threads
+    # exhausted retries and silently lost data. Sequential keeps the
+    # peak concurrent thread count at 10, matching what's been
+    # production-stable.
     topic.queue_generate_article_analytics
-    topic.queue_incremental_topic_build(queue_next_stage: true, force_updates: false)
   end
 
   def expiration

--- a/lib/wiki_action_api.rb
+++ b/lib/wiki_action_api.rb
@@ -540,7 +540,12 @@ class WikiActionApi
         wait_seconds = retry_after.to_i if retry_after
         wait_seconds = [wait_seconds || 0, DEFAULT_RETRY_AFTER_SECONDS].max
         wait_seconds = [wait_seconds, MAX_RETRY_AFTER_SECONDS].min
-        wait_seconds += rand(0.0..0.5)
+        # 0–3 s of jitter, not 0–0.5: under high concurrency (analytics
+        # is now multi-threaded) all retrying threads tend to wake up
+        # near the same Retry-After deadline. With 0–0.5 s jitter on a
+        # 5–30 s wait they re-burst as a near-synchronous herd; 0–3 s
+        # is enough to spread the wave across a few seconds.
+        wait_seconds += rand(0.0..3.0)
         puts "WikiActionApi / 429 Too Many Requests - waiting #{wait_seconds.round(2)}s (attempt #{tries}/#{total_tries})"
         sleep wait_seconds
       else

--- a/lib/wiki_action_api.rb
+++ b/lib/wiki_action_api.rb
@@ -504,12 +504,25 @@ class WikiActionApi
     client
   end
 
+  # Wikimedia OAuth 2 owner-only consumer token (scopes: basic +
+  # highvolume). With this set, requests count against the
+  # consumer's per-account quota (150k req/hr at time of writing) and
+  # get apihighlimits-equivalent paging — vs anonymous's per-IP
+  # bucket that throttles to ~5k req/hr. No-op when the credential
+  # isn't set (e.g. local dev without the credential file decrypted)
+  # so requests fall back to anonymous.
+  def authenticate(client)
+    token = Rails.application.credentials.dig(:wiki, :token)
+    client.oauth_access_token(token) if token
+    client
+  end
+
   def api_client
-    set_user_agent(MediawikiApi::Client.new(@api_url))
+    authenticate(set_user_agent(MediawikiApi::Client.new(@api_url)))
   end
 
   def wikidata_api_client
-    set_user_agent(MediawikiApi::Client.new('https://www.wikidata.org/w/api.php'))
+    authenticate(set_user_agent(MediawikiApi::Client.new('https://www.wikidata.org/w/api.php')))
   end
 
   # Default backoff when the server doesn't send a Retry-After header.

--- a/lib/wiki_rest_api.rb
+++ b/lib/wiki_rest_api.rb
@@ -46,6 +46,9 @@ class WikiRestApi
       faraday.adapter Faraday.default_adapter
     end
     connection.headers['User-Agent'] = Features.user_agent
+    if (token = Rails.application.credentials.dig(:wiki, :token))
+      connection.headers['Authorization'] = "Bearer #{token}"
+    end
     connection
   end
 

--- a/lib/wiki_rest_api.rb
+++ b/lib/wiki_rest_api.rb
@@ -67,7 +67,9 @@ class WikiRestApi
       wait_seconds = retry_after.to_i if retry_after
       wait_seconds = [wait_seconds || 0, DEFAULT_RETRY_AFTER_SECONDS].max
       wait_seconds = [wait_seconds, MAX_RETRY_AFTER_SECONDS].min
-      wait_seconds += rand(0.0..0.5)
+      # 0–3 s of jitter to de-correlate the retry herd; see
+      # wiki_action_api.rb for the full rationale.
+      wait_seconds += rand(0.0..3.0)
       unless Rails.env.test?
         ap "WikiRestApi / 429 Too Many Requests - waiting #{wait_seconds.round(2)}s, tries remaining: #{tries}"
         sleep wait_seconds

--- a/lib/wikimedia_pageviews_api.rb
+++ b/lib/wikimedia_pageviews_api.rb
@@ -68,7 +68,9 @@ class WikimediaPageviewsApi
       wait_seconds = retry_after.to_i if retry_after
       wait_seconds = [wait_seconds || 0, DEFAULT_RETRY_AFTER_SECONDS].max
       wait_seconds = [wait_seconds, MAX_RETRY_AFTER_SECONDS].min
-      wait_seconds += rand(0.0..0.5)
+      # 0–3 s of jitter to de-correlate the retry herd; see
+      # wiki_action_api.rb for the full rationale.
+      wait_seconds += rand(0.0..3.0)
       unless Rails.env.test?
         Rails.logger.warn(
           "WikimediaPageviewsApi / 429 Too Many Requests - " \

--- a/lib/wikimedia_pageviews_api.rb
+++ b/lib/wikimedia_pageviews_api.rb
@@ -50,17 +50,51 @@ class WikimediaPageviewsApi
 
   private
 
+  # Transient network errors that should be retried with backoff.
+  # Faraday::ConnectionFailed wraps Net::OpenTimeout, ECONNRESET, etc.
+  # Faraday::TimeoutError wraps Net::ReadTimeout. SSL handshake
+  # failures show up as Faraday::SSLError. Any of these indicates a
+  # temporary network blip rather than a real "no data" answer, so
+  # the caller would draw the wrong conclusion (returning 0 views) if
+  # we let them propagate or didn't retry.
+  TRANSIENT_NETWORK_ERRORS = [
+    Faraday::ConnectionFailed,
+    Faraday::TimeoutError,
+    Faraday::SSLError
+  ].freeze
+
   # The pageviews endpoint isn't behind Faraday's `:raise_error`
   # middleware, so a 429 comes back as a regular response with
   # status 429. Without this loop the caller silently treats 429
   # like "no data" and returns 0 — masking the throttle and
   # producing wrong analytics. Honor Retry-After (clamped to a
   # 5–60 s window) and retry up to MAX_TRIES times.
+  #
+  # Also catches transient network errors and retries with
+  # exponential backoff — without this, a single timeout against the
+  # pageviews cluster would propagate up through the analytics job
+  # and Sidekiq would auto-retry the entire 6562-article batch from
+  # scratch (a 10-minute regression per blip). After MAX_TRIES,
+  # return nil so the caller can write nil for that one article and
+  # continue.
   def pageviews_get(url)
     tries = 0
     loop do
       tries += 1
-      response = @client.get(url)
+      response = begin
+        @client.get(url)
+      rescue *TRANSIENT_NETWORK_ERRORS => e
+        return nil if tries >= MAX_TRIES
+        backoff = (2**tries) + rand(0.0..3.0)
+        unless Rails.env.test?
+          Rails.logger.warn(
+            "WikimediaPageviewsApi / network error (#{e.class}: #{e.message}) - " \
+            "retrying after #{backoff.round(2)}s (attempt #{tries}/#{MAX_TRIES})"
+          )
+        end
+        sleep backoff
+        next
+      end
       return response unless response&.status == 429
       return response if tries >= MAX_TRIES
 

--- a/spec/sidekiq/generate_article_analytics_job_spec.rb
+++ b/spec/sidekiq/generate_article_analytics_job_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GenerateArticleAnalyticsJob, type: :job do
+  let!(:wiki) { Wiki.find_or_create_by!(language: 'en', project: 'wikipedia') }
+
+  describe '#perform — auto-chain to incremental_topic_build' do
+    context 'for a Topic Builder topic' do
+      let(:topic) do
+        create(:topic, wiki: wiki, tb_handle: 'tbp_abc123',
+                       start_date: Date.new(2024, 1, 1), end_date: Date.new(2024, 12, 31))
+      end
+
+      it 'queues IncrementalTopicBuildJob at the tail (empty article bag short-circuit)' do
+        expect {
+          described_class.new.perform(topic.id)
+        }.to change(IncrementalTopicBuildJob.jobs, :size).by(1)
+      end
+    end
+
+    context 'for a CSV-driven topic (no tb_handle)' do
+      let(:topic) do
+        create(:topic, wiki: wiki, tb_handle: nil,
+                       start_date: Date.new(2024, 1, 1), end_date: Date.new(2024, 12, 31))
+      end
+
+      it 'does not auto-queue IncrementalTopicBuildJob' do
+        expect {
+          described_class.new.perform(topic.id)
+        }.to change(IncrementalTopicBuildJob.jobs, :size).by(0)
+      end
+    end
+
+    context 'for a TB topic that already has a build in flight' do
+      let(:topic) do
+        create(:topic, wiki: wiki, tb_handle: 'tbp_abc123',
+                       incremental_topic_build_job_id: 'in-flight',
+                       start_date: Date.new(2024, 1, 1), end_date: Date.new(2024, 12, 31))
+      end
+
+      it 'does not queue a second IncrementalTopicBuildJob' do
+        expect {
+          described_class.new.perform(topic.id)
+        }.to change(IncrementalTopicBuildJob.jobs, :size).by(0)
+      end
+    end
+  end
+end

--- a/spec/sidekiq/import_topic_builder_articles_job_spec.rb
+++ b/spec/sidekiq/import_topic_builder_articles_job_spec.rb
@@ -63,15 +63,10 @@ RSpec.describe ImportTopicBuilderArticlesJob, type: :job do
     expect(topic.reload.article_import_job_id).to be_nil
   end
 
-  it 'auto-chains article analytics + incremental topic build on success' do
+  it 'auto-chains article analytics on success (analytics chains to timepoint build at its tail)' do
     expect {
       described_class.new.perform(topic.id, handle)
     }.to change(GenerateArticleAnalyticsJob.jobs, :size).by(1)
-      .and change(IncrementalTopicBuildJob.jobs, :size).by(1)
-
-    inc = IncrementalTopicBuildJob.jobs.last['args']
-    # (topic_id, stage, queue_next_stage, force_updates) — start at the
-    # first stage and chain through all four.
-    expect(inc).to eq([topic.id, 'classify', true, false])
+      .and change(IncrementalTopicBuildJob.jobs, :size).by(0)
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -10,9 +10,11 @@ VCR.configure do |config|
   record_mode = ENV['VCR_RECORD']&.to_sym || :once
   config.default_cassette_options = { allow_playback_repeats: true, record: record_mode }
 
-  # Strip the Lift Wing JWT from any request that carries one, so cassettes
-  # never commit a real bearer token.
-  config.filter_sensitive_data('<LIFTWING_TOKEN>') do |interaction|
+  # Strip any Bearer token from outbound requests so cassettes never
+  # commit real credentials. Originally added for the Lift Wing JWT,
+  # now also redacts the Wikimedia OAuth 2 token (Rails creds
+  # wiki.token) used on Action API and REST API requests.
+  config.filter_sensitive_data('<BEARER_TOKEN>') do |interaction|
     interaction.request.headers['Authorization']&.first&.[](/Bearer (\S+)/, 1)
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #55. After watching a 6562-article TB import run end to
end, the dominant wall-clock cost was clearly
`GenerateArticleAnalyticsJob` running fully serial — one worker, ~16
Wikipedia API calls per article, 6562 articles. This PR parallelizes
that phase, swaps to authenticated requests against Wikipedia,
sequential-chains to the timepoint build pipeline, and tightens the
429 retry behavior so the combined burst stays well inside the
account-tier quota instead of the per-IP one.

## Empirical results

A 6562-article climate-change topic, on the local dev box. Two ~3-minute
windows captured before the analytics phase reached steady state:

| | Anonymous, 5 threads | Authenticated, 3 threads |
|---|---|---|
| 429 events in window | **44** | **0** |
| Analytics exceptions | many | **0** |
| Articles processed | ~52 | ~158 |
| Throughput | ~17/min (throttled) | ~45/min |
| Extrapolated full analytics run | ≈ 6+ hours | ≈ **2.4 hours** |

The 0 vs 44 column on `429 events` is the headline: with the bearer
token, we're operating in the ~150k req/hr account-tier quota
instead of the ~5k req/hr per-IP anonymous bucket, and don't trip the
limit at all at 3 threads. Removing retry deadtime is most of the
throughput win.

## What changes

### 1. Parallelize `GenerateArticleAnalyticsJob`

Per article, this job makes ~16 external API calls (more for popular
articles whose backlinks/revisions paginate). At 6562 articles
that's 150k–650k+ HTTP calls; the old serial-loop wall time was the
long pole.

- Body of the per-article loop wrapped in `Parallel.each(in_threads:
  THREADS_COUNT)` with the standard
  `ActiveRecord::Base.connection_pool.with_connection` guard.
- `Mutex` around the `done` and `skipped` counters so the progress
  bar advances monotonically and the final "skipped: N" tally stays
  correct under concurrency.
- The shared `ArticleStatsService` instance is immutable post-init;
  `TimepointService` has been sharing the same shape across
  10-thread `Parallel.each` since well before this change, so the
  pattern is proven.

**Why 3 threads.** Started at 5 because each phase-2 iteration makes
~4× the request density of a phase-3b iteration (which uses 10
threads). Empirically, even 5 saturated the per-IP bucket within
seconds (44 × 429 in ~3 minutes). Dropped to 3 after testing. With
the OAuth bearer also landed, 3 leaves enormous headroom against
the 150k/hr account quota; tunable upward if a future test shows
the bucket can take more.

### 2. Wikimedia OAuth 2 bearer auth on Action + REST APIs

The wmcloud and production credentials already carried an OAuth 2
owner-only consumer token (Rails creds key `wiki.token`, JWT scopes
`basic + highvolume`, 150k req/hr quota). It was unused.

- `WikiActionApi#api_client` and `#wikidata_api_client` now call
  `client.oauth_access_token(token)` after instantiation. The Wiki
  Edu fork of the `mediawiki_api` gem already supports this — the
  helper sets `Authorization: Bearer <token>` on the underlying
  Faraday connection.
- `WikiRestApi#api_client` adds the same header directly since it
  builds Faraday by hand.
- Both guard on the credential being present so local dev (where
  `development.yml.enc` has placeholder values) falls back to
  anonymous without crashing — the existing nil-token case.

**Skipped on `WikimediaPageviewsApi`**: that endpoint is on a
separate analytics cluster (Cassandra-backed AQS, not core
MediaWiki) and there's no documented effect of bearer auth on its
rate limits. Leaving it anonymous; can revisit if pageviews 429s
become a sustained problem (they didn't in the auth'd test run).

**VCR redaction**: the existing `<LIFTWING_TOKEN>` filter was already
host-agnostic (matched any `Authorization: Bearer …` header), so it
catches the new token too — under a now-misleading placeholder
name. Renamed to `<BEARER_TOKEN>` and updated the comment to
document both. Existing cassettes that already have
`<LIFTWING_TOKEN>` baked in continue to play back unchanged.

### 3. Sequential chain analytics → incremental_topic_build

#55's auto-chain fired analytics and the timepoint build pipeline in
*parallel* from `ImportTopicBuilderArticlesJob`. With analytics now
also running on 3 threads and the timepoint phases on 10, the
parallel chain would still mean 13 concurrent enwiki connections at
peak. Even with the auth quota's headroom, the herd-retry failure
mode (threads exhausting their 5-retry budget and silently returning
nil → analytics writer persists nil where the right answer is "data
exists but we couldn't fetch it") wasn't worth keeping around for
zero benefit.

Move the timepoint-build enqueue to the **tail** of
`GenerateArticleAnalyticsJob` so the phases run back-to-back,
capping concurrent threads at 10 — the proven-stable count from
`TimepointService`.

The chain is gated on `topic.tb_handle.present?`, so CSV-driven
topics keep their existing manual-button flow unchanged.

### 4. Jitter bump on 429 retry: 0–0.5s → 0–3s

`WikiActionApi#mediawiki`, `WikiRestApi#make_request`, and
`WikimediaPageviewsApi#pageviews_get` all sleep
`Retry-After + jitter` on a 429. The 0–0.5s jitter was negligible
relative to a 5–30s `Retry-After`. Under multi-threaded
concurrency, all retrying threads wake up nearly together and
re-burst as a herd, often re-tripping the same limit.

3s of jitter spreads the wave across a few seconds — enough for the
per-IP bucket to refill between threads. Belt-and-suspenders for
the parallelization above; the auth bearer in #2 should make 429s
rare in the first place, but jitter is the safety net.

### 5. Pre-existing bug fix: `get_talk_page_size_at_date` nil-deref

Shaken out by the local pipeline test. The method has a guarded
`revision ? revision['size'] : nil` return, but a
`Rails.logger.info` line above it dereferences `revision['size']`
unconditionally — so when a talk page doesn't exist (or 429
exhaustion returns nil), every miss raises `NoMethodError`. The
outer `rescue StandardError` catches it and returns nil (correct
outcome for the analytics row), so no wrong data is persisted, but
every miss fires a noisy ERROR-level log line. On the climate-change
run that's hundreds of misleading errors. Move the log behind an
early-return on nil. Drive-by — predates this PR.

## Trade-offs

- **Sequential phases lengthen wall-clock for small-topic users.**
  For a 50-article topic, analytics + timepoints used to run in
  parallel; now they run back-to-back. The penalty is bounded by
  the smaller of the two phase durations, and small-topic users
  were not the ones complaining about hours-long imports.
- **3 threads is conservative for the auth-tier quota.** Easy to
  retune upward; left here so the per-thread retry handler is the
  exception, not the rule.
- **Pageviews API still anonymous.** Could be a future stragglers'
  fix if it shows up in production logs.
- **Per-thread retry, no global token bucket.** A coordinator
  would be cleaner but it's infrastructure (out of scope for "easy
  wins"). The jitter bump approximates the effect at one-line cost.

## Testing

```
350 examples, 0 failures
```

Specs added:

- `spec/sidekiq/generate_article_analytics_job_spec.rb` — for a TB
  topic, the job queues `IncrementalTopicBuildJob` at its tail; for
  a CSV topic, it does not; if a build is already in flight, no
  second one is queued.

Specs updated:

- `spec/sidekiq/import_topic_builder_articles_job_spec.rb` — the
  ingest job now only queues analytics, not the timepoint build
  directly. Analytics chains on the timepoint build itself.

Manually verified end-to-end on the 6562-article climate-change
topic, anonymous and authenticated, with the numbers in the
**Empirical results** table above.

Not asserted (would be a thread-stress harness): no thread-safety
issues in `Parallel.each` against the shared `ArticleStatsService`.
The pattern is borrowed from `TimepointService`, which has used it
in production with 10 threads for years.

## Out of scope

The audit that motivated this PR also surfaced several other easy
wins. They're separate PRs, not this one:

- Eager-load `topic_article_timepoints.includes(:article_timepoint)`
  in `TopicTimepointStatsService` — kills ~164k N+1 SELECTs.
- Stop redundant `update_details_for_article` calls inside
  `ArticleStatsService` `get_*` helpers — saves ~78k DB round-trips
  per analytics run.
- De-duplicate revision lookups for `(end_date)` between
  `get_article_size_at_date` and `get_lead_section_size_at_date`.
- Replace `get_unique_editors_count`'s paginated revision walk with
  the `prop=contributors` endpoint or a capped estimate.

## Stack

This PR is stacked on #55 — base branch is `TopicBuilderIntegration`.
Merge #55 first, or rebase to master once that lands.
