### PR TITLE
CSS refactor + new chart features

### DIFF
--- a/app/frontend/components/article-detail-panel.component.tsx
+++ b/app/frontend/components/article-detail-panel.component.tsx
@@ -101,27 +101,27 @@ function ArticleDetailPanel({
 
   return (
     <div
-      className="ArticleDetailPanelBackdrop"
+      className="ArticleDetail"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="ArticleDetailPanel">
-        <div className="ArticleDetailPanelHeader">
-          <h3 className="ArticleDetailPanelTitle">
+      <div className="Panel">
+        <div className="Header">
+          <h3 className="Title">
             {article.article}
             <a
               href={wikiUrl}
               target="_blank"
               rel="noreferrer"
-              className="ArticleDetailPanelTitleLink"
+              className="TitleLink"
               aria-label="Open on Wikipedia"
             >
               <FiExternalLink size={18} />
             </a>
           </h3>
           <button
-            className="ArticleDetailPanelClose"
+            className="Close"
             onClick={onClose}
             aria-label="Close"
           >
@@ -129,55 +129,55 @@ function ArticleDetailPanel({
           </button>
         </div>
 
-        <div className="ArticleDetailPanelBody">
-          <div className="ArticleDetailInfo">
-            <div className="ArticleDetailInfoHeader">Article information</div>
-            <div className="ArticleDetailColBody">
-              <div className="ArticleDetailInfoSection">
-                <div className="ArticleDetailInfoSectionTitle">General</div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Instance</span>
-                  <span className="ArticleDetailInfoValue">
+        <div className="Body">
+          <div className="Info">
+            <div className="Header">Article information</div>
+            <div className="ColBody">
+              <div className="Section">
+                <div className="Title">General</div>
+                <div className="Row">
+                  <span className="Label">Instance</span>
+                  <span className="Value">
                     {instanceLabel}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Creation date</span>
-                  <span className="ArticleDetailInfoValue">
+                <div className="Row">
+                  <span className="Label">Creation date</span>
+                  <span className="Value">
                     {formattedDate}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Restriction</span>
-                  <span className="ArticleDetailInfoValue">
+                <div className="Row">
+                  <span className="Label">Restriction</span>
+                  <span className="Value">
                     {restrictionLabel}
                   </span>
                 </div>
               </div>
 
-              <div className="ArticleDetailInfoSection">
-                <div className="ArticleDetailInfoSectionTitle">
+              <div className="Section">
+                <div className="Title">
                   Qualitative information
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">
+                <div className="Row">
+                  <span className="Label">
                     Quality assessment
                   </span>
-                  <span className="ArticleDetailInfoValue">
+                  <span className="Value">
                     {article.assessment_grade ?? "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Centrality</span>
-                  <span className="ArticleDetailInfoValue">
+                <div className="Row">
+                  <span className="Label">Centrality</span>
+                  <span className="Value">
                     {article.centrality != null
                       ? article.centrality.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Warning tags</span>
-                  <span className="ArticleDetailInfoValue">
+                <div className="Row">
+                  <span className="Label">Warning tags</span>
+                  <span className="Value">
                     {article.warning_tags_count != null
                       ? article.warning_tags_count.toLocaleString()
                       : "—"}
@@ -185,53 +185,53 @@ function ArticleDetailPanel({
                 </div>
               </div>
 
-              <div className="ArticleDetailInfoSection">
-                <div className="ArticleDetailInfoSectionTitle">
+              <div className="Section">
+                <div className="Title">
                   Content data
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">
+                <div className="Row">
+                  <span className="Label">
                     Article size (in byte)
                   </span>
-                  <span className="ArticleDetailInfoValue">
+                  <span className="Value">
                     {article.article_size != null
                       ? article.article_size.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">
+                <div className="Row">
+                  <span className="Label">
                     Lead section size (in byte)
                   </span>
-                  <span className="ArticleDetailInfoValue">
+                  <span className="Value">
                     {article.lead_section_size != null
                       ? article.lead_section_size.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">
+                <div className="Row">
+                  <span className="Label">
                     Discussion size (in byte)
                   </span>
-                  <span className="ArticleDetailInfoValue">
+                  <span className="Value">
                     {article.talk_size != null
                       ? article.talk_size.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Images</span>
-                  <span className="ArticleDetailInfoValue">
+                <div className="Row">
+                  <span className="Label">Images</span>
+                  <span className="Value">
                     {article.images_count != null
                       ? article.images_count.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">
+                <div className="Row">
+                  <span className="Label">
                     Linguistic versions
                   </span>
-                  <span className="ArticleDetailInfoValue">
+                  <span className="Value">
                     {article.linguistic_versions_count != null
                       ? article.linguistic_versions_count.toLocaleString()
                       : "—"}
@@ -239,41 +239,41 @@ function ArticleDetailPanel({
                 </div>
               </div>
 
-              <div className="ArticleDetailInfoSection">
-                <div className="ArticleDetailInfoSectionTitle">
+              <div className="Section">
+                <div className="Title">
                   User engagement data
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">
+                <div className="Row">
+                  <span className="Label">
                     Avg daily views
                   </span>
-                  <span className="ArticleDetailInfoValue">
+                  <span className="Value">
                     {article.average_daily_views != null
                       ? article.average_daily_views.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">
+                <div className="Row">
+                  <span className="Label">
                     Avg daily views (prev. year)
                   </span>
-                  <span className="ArticleDetailInfoValue">
+                  <span className="Value">
                     {article.prev_average_daily_views != null
                       ? article.prev_average_daily_views.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Editors</span>
-                  <span className="ArticleDetailInfoValue">
+                <div className="Row">
+                  <span className="Label">Editors</span>
+                  <span className="Value">
                     {article.number_of_editors != null
                       ? article.number_of_editors.toLocaleString()
                       : "—"}
                   </span>
                 </div>
-                <div className="ArticleDetailInfoRow">
-                  <span className="ArticleDetailInfoLabel">Incoming links</span>
-                  <span className="ArticleDetailInfoValue">
+                <div className="Row">
+                  <span className="Label">Incoming links</span>
+                  <span className="Value">
                     {article.incoming_links_count != null
                       ? article.incoming_links_count.toLocaleString()
                       : "—"}
@@ -283,38 +283,38 @@ function ArticleDetailPanel({
             </div>
           </div>
 
-          <div className="ArticleDetailContent">
-            <div className="ArticleDetailContentHeader">
-              <span className="ArticleDetailContentTitle">
+          <div className="Content">
+            <div className="Header">
+              <span className="Title">
                 Content analysis
               </span>
-              <span className="ArticleDetailContentSubtitle">
+              <span className="Subtitle">
                 | Terms occurring more frequently
               </span>
             </div>
-            <div className="ArticleDetailContentTabs">
+            <div className="Tabs">
               <button
-                className={`ArticleDetailContentTab${activeTab === "all" ? " is-active" : ""}`}
+                className={`Tab${activeTab === "all" ? " is-active" : ""}`}
                 onClick={() => setActiveTab("all")}
               >
                 All terms
               </button>
               <button
-                className={`ArticleDetailContentTab${activeTab === "peacock" ? " is-active" : ""}`}
+                className={`Tab${activeTab === "peacock" ? " is-active" : ""}`}
                 onClick={() => setActiveTab("peacock")}
               >
                 Peacock terms
               </button>
             </div>
-            <div className="ArticleDetailColBody">
-              <div className="ArticleDetailWordCloud">
+            <div className="ColBody">
+              <div className="WordCloud">
                 {loadingWords && (
-                  <div className="ArticleDetailWordCloudSpinner">
+                  <div className="SpinnerWrap">
                     <Spinner size="large" />
                   </div>
                 )}
                 {!loadingWords && displayedWords.length === 0 && (
-                  <span className="ArticleDetailWordCloudMessage">
+                  <span className="Message">
                     No terms found.
                   </span>
                 )}
@@ -322,7 +322,7 @@ function ArticleDetailPanel({
                   displayedWords.map(({ word, count }) => (
                     <span
                       key={word}
-                      className="ArticleDetailWordCloudWord"
+                      className="Word"
                       style={{
                         fontSize: `${0.75 + Math.pow(count / maxCount, 0.5) * 2.75}rem`,
                       }}
@@ -334,20 +334,20 @@ function ArticleDetailPanel({
             </div>
           </div>
 
-          <div className="ArticleDetailContrib">
-            <div className="ArticleDetailContribSectionHeader">
+          <div className="Contrib">
+            <div className="SectionHeader">
               Contribution
             </div>
-            <div className="ArticleDetailColBody">
-              <div className="ArticleDetailContribHeader">
+            <div className="ColBody">
+              <div className="Header">
                 You can contribute to increase the quality of this article.
               </div>
-              <ul className="ArticleDetailContribList">
+              <ul className="List">
                 {contributions.map((item) => (
-                  <li key={item} className="ArticleDetailContribItem">
+                  <li key={item} className="Item">
                     <FaArrowRight
                       size={12}
-                      className="ArticleDetailContribArrow"
+                      className="Arrow"
                     />
                     <span>{item}</span>
                   </li>

--- a/app/frontend/components/article-detail-panel.component.tsx
+++ b/app/frontend/components/article-detail-panel.component.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { FaArrowRight } from "react-icons/fa6";
 import { FiExternalLink } from "react-icons/fi";
 import { IoClose } from "react-icons/io5";
@@ -6,9 +7,10 @@ import Spinner from "./spinner.component";
 import type { ArticleAnalytics } from "../types/bubble-chart.type";
 import { getWikiUrl } from "../utils/search-utils";
 import {
-  computeWordFrequencies,
+  fetchArticleWordFrequencies,
   PEACOCK_TERMS,
 } from "../utils/word-cloud-utils";
+import { fetchArticleNeeds } from "../utils/article-quality-utils";
 
 type Wiki = {
   language: string;
@@ -23,15 +25,6 @@ export type ArticleRow = {
   has_edit_restriction: boolean;
 } & ArticleAnalytics;
 
-const contributions = [
-  "Add reliable, high-quality sources",
-  "Improve the lead section by adding some information",
-  "Remove the warning tags",
-  "Add internal and external links thoughtfully",
-  "When appropriate, add some images",
-  "Copyedit for clarity and consistency",
-];
-
 function ArticleDetailPanel({
   article,
   wiki,
@@ -42,30 +35,22 @@ function ArticleDetailPanel({
   onClose: () => void;
 }) {
   const [activeTab, setActiveTab] = useState<"all" | "peacock">("all");
-  const [words, setWords] = useState<{ word: string; count: number }[]>([]);
-  const [loadingWords, setLoadingWords] = useState(false);
+  const lang = wiki?.language ?? "en";
+  const project = wiki?.project ?? "wikipedia";
+  const isWikipedia = project === "wikipedia";
 
-  useEffect(() => {
-    setLoadingWords(true);
-    setWords([]);
-    const lang = wiki?.language ?? "en";
-    const project = wiki?.project ?? "wikipedia";
-    const url =
-      `https://${lang}.${project}.org/w/api.php?` +
-      `action=query&prop=extracts&explaintext=true&exsectionformat=plain` +
-      `&titles=${encodeURIComponent(article.article)}&format=json&origin=*`;
+  const { data: words = [], isLoading: loadingWords } = useQuery({
+    queryKey: ["articleWordFrequencies", lang, project, article.article],
+    queryFn: () => fetchArticleWordFrequencies(article.article, lang, project),
+    staleTime: 60 * 60 * 1000,
+  });
 
-    fetch(url)
-      .then((r) => r.json())
-      .then((data) => {
-        const pages = data?.query?.pages ?? {};
-        const page = Object.values(pages)[0] as any;
-        const extract: string = page?.extract ?? "";
-        setWords(computeWordFrequencies(extract));
-      })
-      .catch(() => setWords([]))
-      .finally(() => setLoadingWords(false));
-  }, [article.article, wiki]);
+  const { data: needs = [], isLoading: loadingNeeds } = useQuery({
+    queryKey: ["articleNeeds", lang, article.article],
+    queryFn: () => fetchArticleNeeds(article.article, lang),
+    enabled: isWikipedia,
+    staleTime: 60 * 60 * 1000,
+  });
 
   const displayedWords =
     activeTab === "peacock"
@@ -120,11 +105,7 @@ function ArticleDetailPanel({
               <FiExternalLink size={18} />
             </a>
           </h3>
-          <button
-            className="Close"
-            onClick={onClose}
-            aria-label="Close"
-          >
+          <button className="Close" onClick={onClose} aria-label="Close">
             <IoClose size={28} />
           </button>
         </div>
@@ -137,32 +118,22 @@ function ArticleDetailPanel({
                 <div className="Title">General</div>
                 <div className="Row">
                   <span className="Label">Instance</span>
-                  <span className="Value">
-                    {instanceLabel}
-                  </span>
+                  <span className="Value">{instanceLabel}</span>
                 </div>
                 <div className="Row">
                   <span className="Label">Creation date</span>
-                  <span className="Value">
-                    {formattedDate}
-                  </span>
+                  <span className="Value">{formattedDate}</span>
                 </div>
                 <div className="Row">
                   <span className="Label">Restriction</span>
-                  <span className="Value">
-                    {restrictionLabel}
-                  </span>
+                  <span className="Value">{restrictionLabel}</span>
                 </div>
               </div>
 
               <div className="Section">
-                <div className="Title">
-                  Qualitative information
-                </div>
+                <div className="Title">Qualitative information</div>
                 <div className="Row">
-                  <span className="Label">
-                    Quality assessment
-                  </span>
+                  <span className="Label">Quality assessment</span>
                   <span className="Value">
                     {article.assessment_grade ?? "—"}
                   </span>
@@ -186,13 +157,9 @@ function ArticleDetailPanel({
               </div>
 
               <div className="Section">
-                <div className="Title">
-                  Content data
-                </div>
+                <div className="Title">Content data</div>
                 <div className="Row">
-                  <span className="Label">
-                    Article size (in byte)
-                  </span>
+                  <span className="Label">Article size (in byte)</span>
                   <span className="Value">
                     {article.article_size != null
                       ? article.article_size.toLocaleString()
@@ -200,9 +167,7 @@ function ArticleDetailPanel({
                   </span>
                 </div>
                 <div className="Row">
-                  <span className="Label">
-                    Lead section size (in byte)
-                  </span>
+                  <span className="Label">Lead section size (in byte)</span>
                   <span className="Value">
                     {article.lead_section_size != null
                       ? article.lead_section_size.toLocaleString()
@@ -210,9 +175,7 @@ function ArticleDetailPanel({
                   </span>
                 </div>
                 <div className="Row">
-                  <span className="Label">
-                    Discussion size (in byte)
-                  </span>
+                  <span className="Label">Discussion size (in byte)</span>
                   <span className="Value">
                     {article.talk_size != null
                       ? article.talk_size.toLocaleString()
@@ -228,9 +191,7 @@ function ArticleDetailPanel({
                   </span>
                 </div>
                 <div className="Row">
-                  <span className="Label">
-                    Linguistic versions
-                  </span>
+                  <span className="Label">Linguistic versions</span>
                   <span className="Value">
                     {article.linguistic_versions_count != null
                       ? article.linguistic_versions_count.toLocaleString()
@@ -240,13 +201,9 @@ function ArticleDetailPanel({
               </div>
 
               <div className="Section">
-                <div className="Title">
-                  User engagement data
-                </div>
+                <div className="Title">User engagement data</div>
                 <div className="Row">
-                  <span className="Label">
-                    Avg daily views
-                  </span>
+                  <span className="Label">Avg daily views</span>
                   <span className="Value">
                     {article.average_daily_views != null
                       ? article.average_daily_views.toLocaleString()
@@ -254,9 +211,7 @@ function ArticleDetailPanel({
                   </span>
                 </div>
                 <div className="Row">
-                  <span className="Label">
-                    Avg daily views (prev. year)
-                  </span>
+                  <span className="Label">Avg daily views (prev. year)</span>
                   <span className="Value">
                     {article.prev_average_daily_views != null
                       ? article.prev_average_daily_views.toLocaleString()
@@ -285,9 +240,7 @@ function ArticleDetailPanel({
 
           <div className="Content">
             <div className="Header">
-              <span className="Title">
-                Content analysis
-              </span>
+              <span className="Title">Content analysis</span>
               <span className="Subtitle">
                 | Terms occurring more frequently
               </span>
@@ -314,9 +267,7 @@ function ArticleDetailPanel({
                   </div>
                 )}
                 {!loadingWords && displayedWords.length === 0 && (
-                  <span className="Message">
-                    No terms found.
-                  </span>
+                  <span className="Message">No terms found.</span>
                 )}
                 {!loadingWords &&
                   displayedWords.map(({ word, count }) => (
@@ -335,24 +286,37 @@ function ArticleDetailPanel({
           </div>
 
           <div className="Contrib">
-            <div className="SectionHeader">
-              Contribution
-            </div>
+            <div className="SectionHeader">Contribution</div>
             <div className="ColBody">
               <div className="Header">
                 You can contribute to increase the quality of this article.
               </div>
-              <ul className="List">
-                {contributions.map((item) => (
-                  <li key={item} className="Item">
-                    <FaArrowRight
-                      size={12}
-                      className="Arrow"
-                    />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
+              {loadingNeeds && (
+                <div className="SpinnerWrap">
+                  <Spinner size="large" />
+                </div>
+              )}
+              {!loadingNeeds && !isWikipedia && (
+                <span className="Message">
+                  Contribution suggestions are available for Wikipedia articles
+                  only.
+                </span>
+              )}
+              {!loadingNeeds && isWikipedia && needs.length === 0 && (
+                <span className="Message">
+                  No specific improvements suggested for this article.
+                </span>
+              )}
+              {!loadingNeeds && isWikipedia && needs.length > 0 && (
+                <ul className="List">
+                  {needs.map((item) => (
+                    <li key={item} className="Item">
+                      <FaArrowRight size={12} className="Arrow" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           </div>
         </div>

--- a/app/frontend/components/article-language-comparison-modal.component.tsx
+++ b/app/frontend/components/article-language-comparison-modal.component.tsx
@@ -71,16 +71,16 @@ function ArticleLanguageComparisonModal({
 
   return (
     <div
-      className="ArticleLangComparisonBackdrop"
+      className="ArticleLangComparison"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="ArticleLangComparisonPanel">
-        <div className="ArticleLangComparisonHeader">
-          <h3 className="ArticleLangComparisonTitle">{articleTitle}</h3>
+      <div className="Panel">
+        <div className="Header">
+          <h3 className="Title">{articleTitle}</h3>
           <button
-            className="ArticleLangComparisonClose"
+            className="Close"
             onClick={onClose}
             aria-label="Close"
           >
@@ -88,30 +88,30 @@ function ArticleLanguageComparisonModal({
           </button>
         </div>
 
-        <div className="ArticleLangComparisonBody">
+        <div className="Body">
           {loading && (
-            <div className="ArticleLangComparisonLoading">
+            <div className="Loading">
               <Spinner size="large" />
             </div>
           )}
 
           {error && (
-            <div className="ArticleLangComparisonError">
+            <div className="Error">
               Failed to load language comparison data.
             </div>
           )}
 
           {!loading && !error && data && (
-            <table className="ArticleLangComparisonTable">
+            <table className="Table">
               <thead>
                 <tr>
-                  <th className="ArticleLangComparisonMetricHeader" />
+                  <th className="MetricHeader" />
                   {languages.map((lang) => {
                     const entry = data[lang];
                     return (
                       <th
                         key={lang}
-                        className={`ArticleLangComparisonLangHeader${!entry ? " ArticleLangComparisonLangHeader--missing" : ""}`}
+                        className={`LangHeader${!entry ? " LangHeader--missing" : ""}`}
                       >
                         <span>{LANGUAGE_LABELS[lang] ?? lang} version</span>
                         {entry && (
@@ -119,7 +119,7 @@ function ArticleLanguageComparisonModal({
                             href={getWikiUrl(entry.title, { language: lang })}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="ArticleLangComparisonHeaderLink"
+                            className="Link"
                             aria-label={`Open ${LANGUAGE_LABELS[lang]} version`}
                           >
                             <FiExternalLink size={14} />
@@ -133,7 +133,7 @@ function ArticleLanguageComparisonModal({
               <tbody>
                 {METRIC_ROWS.map((metric) => (
                   <tr key={metric.key}>
-                    <td className="ArticleLangComparisonMetricLabel">
+                    <td className="MetricLabel">
                       {metric.label}
                     </td>
                     {languages.map((lang) => {
@@ -142,9 +142,9 @@ function ArticleLanguageComparisonModal({
                         return (
                           <td
                             key={lang}
-                            className="ArticleLangComparisonCell ArticleLangComparisonCell--missing"
+                            className="Cell Cell--missing"
                           >
-                            <span className="ArticleLangComparisonMissingIcon">
+                            <span className="MissingIcon">
                               <IoCloseCircle size={22} />
                             </span>
                           </td>
@@ -156,14 +156,14 @@ function ArticleLanguageComparisonModal({
                       const barWidth = max > 0 ? (value / max) * 100 : 0;
 
                       return (
-                        <td key={lang} className="ArticleLangComparisonCell">
-                          <div className="ArticleLangComparisonCellInner">
-                            <span className="ArticleLangComparisonValue">
+                        <td key={lang} className="Cell">
+                          <div className="Inner">
+                            <span className="Value">
                               {value.toLocaleString()}
                             </span>
-                            <div className="ArticleLangComparisonBarTrack">
+                            <div className="Track">
                               <div
-                                className="ArticleLangComparisonBar"
+                                className="Bar"
                                 style={{ width: `${barWidth}%` }}
                               />
                             </div>
@@ -175,21 +175,21 @@ function ArticleLanguageComparisonModal({
                 ))}
 
                 <tr>
-                  <td className="ArticleLangComparisonMetricLabel" />
+                  <td className="MetricLabel" />
                   {languages.map((lang) => {
                     const entry = data[lang];
                     if (entry) {
                       return (
-                        <td key={lang} className="ArticleLangComparisonCell" />
+                        <td key={lang} className="Cell" />
                       );
                     }
                     return (
                       <td
                         key={lang}
-                        className="ArticleLangComparisonCell ArticleLangComparisonCell--missing ArticleLangComparisonCell--translate"
+                        className="Cell Cell--missing Cell--translate"
                       >
                         <a
-                          className="ArticleLangComparisonTranslateLink"
+                          className="TranslateLink"
                           href={getTranslateUrl(articleTitle, sourceLang, lang)}
                           target="_blank"
                           rel="noopener noreferrer"

--- a/app/frontend/components/article-languages-grid.component.tsx
+++ b/app/frontend/components/article-languages-grid.component.tsx
@@ -67,13 +67,13 @@ function LanguageCell({
 }) {
   if (!exists) {
     return (
-      <td className="ArticleLangCell ArticleLangCell--missing">
-        <span className="ArticleLangCellMissing">
+      <td className="Cell Cell--missing">
+        <span className="Missing">
           <IoCloseCircle size={18} />
           <span>Missing</span>
         </span>
         <a
-          className="ArticleLangCellTranslate"
+          className="Translate"
           href={getTranslateUrl(articleTitle, sourceLang, lang)}
           target="_blank"
           rel="noopener noreferrer"
@@ -137,9 +137,9 @@ function PaginationBar({
   }
 
   return (
-    <div className="ArticleLangPagination">
+    <div className="Pagination">
       <button
-        className="ArticleLangPaginationBtn"
+        className="Btn"
         disabled={currentPage === 1}
         onClick={() => goToPage(currentPage - 1)}
         aria-label="Previous page"
@@ -148,13 +148,13 @@ function PaginationBar({
       </button>
       {pages.map((p, i) =>
         p === "ellipsis" ? (
-          <span key={`e${i}`} className="ArticleLangPaginationEllipsis">
+          <span key={`e${i}`} className="Ellipsis">
             &hellip;
           </span>
         ) : (
           <button
             key={p}
-            className={`ArticleLangPaginationBtn ${p === currentPage ? "is-active" : ""}`}
+            className={`Btn ${p === currentPage ? "is-active" : ""}`}
             onClick={() => goToPage(p)}
           >
             {p}
@@ -162,7 +162,7 @@ function PaginationBar({
         ),
       )}
       <button
-        className="ArticleLangPaginationBtn"
+        className="Btn"
         disabled={currentPage === totalPages}
         onClick={() => goToPage(currentPage + 1)}
         aria-label="Next page"
@@ -269,9 +269,9 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
         : 0;
 
     return (
-      <div className="ArticleLangGridLoading">
+      <div className="Grid--loading">
         <Spinner size="large" />
-        <div className="ArticleLangGridLoadingText">
+        <div className="LoadingText">
           Fetching language data&hellip;{" "}
           {progress && progress.total > 0 && (
             <span>
@@ -280,9 +280,9 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
           )}
         </div>
         {progress && progress.total > 0 && (
-          <div className="ArticleLangProgressTrack">
+          <div className="Progress">
             <div
-              className="ArticleLangProgressBar"
+              className="Bar"
               style={{ width: `${pct}%` }}
             />
           </div>
@@ -292,24 +292,24 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
   }
 
   if (error) {
-    return <div className="ArticleLangGridError">{error}</div>;
+    return <div className="Grid--error">{error}</div>;
   }
 
   if (articles.length === 0) {
     return (
-      <div className="ArticleLangGridEmpty">
+      <div className="Grid--empty">
         No articles match the current filters.
       </div>
     );
   }
 
   return (
-    <div className="ArticleLangGrid">
-      <table className="ArticleLangTable">
+    <div className="Grid">
+      <table className="Table">
         <thead>
           <tr>
-            <th className="ArticleLangTableHeaderArticle">
-              <div className="ArticleLangTableHeaderArticle__inner">
+            <th className="HeaderArticle">
+              <div className="Inner">
                 <BsInfoCircle size={24} />
                 <span>
                   Compare different linguistic versions of the article
@@ -317,7 +317,7 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
               </div>
             </th>
             {languages.map((lang) => (
-              <th key={lang} className="ArticleLangTableHeaderLang">
+              <th key={lang} className="HeaderLang">
                 {LANGUAGE_LABELS[lang] ?? lang} version
               </th>
             ))}
@@ -337,9 +337,9 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
               !langQueries[rowIdx]?.isError;
 
             return (
-              <tr key={row.article} className="ArticleLangRow">
+              <tr key={row.article} className="Row">
                 <td
-                  className={`ArticleLangRowTitle${onArticleClick ? " ArticleLangRowTitle--clickable" : ""}`}
+                  className={`Title${onArticleClick ? " Title--clickable" : ""}`}
                   onClick={() => onArticleClick?.(row.article)}
                 >
                   {row.article}

--- a/app/frontend/components/article-search-autocomplete.component.tsx
+++ b/app/frontend/components/article-search-autocomplete.component.tsx
@@ -92,13 +92,13 @@ const ArticleSearchAutocomplete: React.FC<ArticleSearchAutocompleteProps> = ({
   return (
     <>
       <div
-        className="ArticleSearchAutocompleteWrapper"
+        className="ArticleSearchAutocomplete"
         ref={suggestionsRef as RefObject<HTMLDivElement>}
       >
-        <GoSearch className="ArticleSearchAutocompleteIcon" />
+        <GoSearch className="Icon" />
         <input
           type="search"
-          className="ArticleSearchAutocompleteInput"
+          className="Input"
           placeholder="Search article"
           value={searchTerm}
           onChange={(e) => handleInputChange(e.target.value)}
@@ -106,14 +106,12 @@ const ArticleSearchAutocomplete: React.FC<ArticleSearchAutocompleteProps> = ({
           onKeyDown={handleKeyDown}
         />
         {showSuggestions && suggestions.length > 0 && (
-          <ul className="ArticleSearchAutocompleteList" ref={listRef}>
+          <ul className="List" ref={listRef}>
             {suggestions.map((title, i) => (
               <li
                 key={title}
                 ref={(el) => (itemRefs.current[i] = el)}
-                className={`ArticleSearchAutocompleteItem ${
-                  activeSuggestion === i ? "is-active" : ""
-                }`}
+                className={`Item ${activeSuggestion === i ? "is-active" : ""}`}
                 onClick={() => handleSuggestionClick(title)}
                 onMouseEnter={() => setActiveSuggestion(i)}
               >

--- a/app/frontend/components/bubble-cell.component.tsx
+++ b/app/frontend/components/bubble-cell.component.tsx
@@ -19,9 +19,9 @@ const BubbleCell: React.FC<BubbleCellProps> = ({
 }) => {
   if (isLoading || isQueued) {
     return (
-      <td className="ArticleLangCell ArticleLangCell--present">
+      <td className="Cell Cell--present">
         <svg
-          className={`ArticleLangCellSkeleton ArticleLangCellSkeleton--${isLoading ? "loading" : "queued"}`}
+          className={`Skeleton Skeleton--${isLoading ? "loading" : "queued"}`}
           width={BUBBLE_BOX}
           height={BUBBLE_BOX}
           viewBox={`-${BUBBLE_HALF} -${BUBBLE_HALF} ${BUBBLE_BOX} ${BUBBLE_BOX}`}
@@ -41,9 +41,9 @@ const BubbleCell: React.FC<BubbleCellProps> = ({
   }
 
   return (
-    <td className="ArticleLangCell ArticleLangCell--present">
+    <td className="Cell Cell--present">
       <svg
-        className="ArticleLangCellBubble"
+        className="Bubble"
         width={BUBBLE_BOX}
         height={BUBBLE_BOX}
         viewBox={`-${BUBBLE_HALF} -${BUBBLE_HALF} ${BUBBLE_BOX} ${BUBBLE_BOX}`}

--- a/app/frontend/components/filtered-articles-sidebar.component.tsx
+++ b/app/frontend/components/filtered-articles-sidebar.component.tsx
@@ -32,10 +32,10 @@ function SidebarRow(props: SidebarRowProps): React.ReactElement | null {
   if (!articleRow) return null;
 
   return (
-    <li style={style} className="FilteredArticlesSidebarItem">
+    <li style={style} className="Item">
       <button
         type="button"
-        className="FilteredArticlesSidebarLink"
+        className="Link"
         onClick={() => onArticleClick?.(articleRow)}
       >
         {articleRow.article}
@@ -47,7 +47,7 @@ function SidebarRow(props: SidebarRowProps): React.ReactElement | null {
         })}
         target="_blank"
         rel="noopener noreferrer"
-        className="FilteredArticlesSidebarExternalLink"
+        className="ExternalLink"
         onClick={(e) => e.stopPropagation()}
       >
         <FiExternalLink />
@@ -62,29 +62,29 @@ const FilteredArticlesSidebar: React.FC<FilteredArticlesSidebarProps> =
       <div className={`FilteredArticlesSidebar ${isOpen ? "is-open" : ""}`}>
         <button
           type="button"
-          className="FilteredArticlesSidebarToggle"
+          className="Toggle"
           onClick={onToggle}
           aria-label={isOpen ? "Close sidebar" : "Open sidebar"}
         >
-          <span className="FilteredArticlesSidebarToggleIcon">
+          <span className="Icon">
             {isOpen ? <GoTriangleRight /> : <GoTriangleLeft />}
           </span>
-          <span className="FilteredArticlesSidebarToggleCount">
+          <span className="Count">
             {articles.length}
           </span>
         </button>
-        <div className="FilteredArticlesSidebarContent">
-          <div className="FilteredArticlesSidebarHeader">
-            <span className="FilteredArticlesSidebarTitle">
+        <div className="Content">
+          <div className="Header">
+            <span className="Title">
               Filtered Articles
             </span>
-            <span className="FilteredArticlesSidebarCount">
+            <span className="Count">
               {articles.length} article{articles.length !== 1 ? "s" : ""}
             </span>
           </div>
           {isOpen && (
             <List
-              className="FilteredArticlesSidebarList"
+              className="List"
               rowComponent={SidebarRow}
               rowCount={articles.length}
               rowHeight={ITEM_HEIGHT}

--- a/app/frontend/components/glossary-modal.component.tsx
+++ b/app/frontend/components/glossary-modal.component.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { BsBook } from "react-icons/bs";
+import { IoClose } from "react-icons/io5";
+
+type GlossaryTerm = { name: string; def: string; color?: string };
+type GlossarySection = {
+  title: string;
+  intro?: string;
+  terms: GlossaryTerm[];
+};
+
+const GLOSSARY_SECTIONS: GlossarySection[] = [
+  {
+    title: "Quality assessment grades",
+    intro:
+      "Ratings assigned by the Wikipedia community to reflect article quality. May be inconsistent across articles.",
+    terms: [
+      {
+        name: "Featured Article (FA) / Featured List (FL)",
+        color: "#9CBDFF",
+        def: "Wikipedia's highest quality rating, awarded after in-depth peer review.",
+      },
+      {
+        name: "A-Class",
+        color: "#66FFFF",
+        def: "Well-organized and essentially complete, reviewed by a WikiProject.",
+      },
+      {
+        name: "Good Article (GA)",
+        color: "#66FF66",
+        def: "Reviewed and confirmed to meet the Good Article criteria, but not yet Featured.",
+      },
+      {
+        name: "B-Class",
+        color: "#B2FF66",
+        def: "Mostly complete, but still needs work to reach Good Article standards.",
+      },
+      {
+        name: "C-Class",
+        color: "#FFFF66",
+        def: "Substantial, but missing important content or containing some irrelevant material.",
+      },
+      {
+        name: "Start",
+        color: "#FFAA66",
+        def: "Started but still quite incomplete.",
+      },
+      {
+        name: "Stub",
+        color: "#FFA4A4",
+        def: "Very short, with only basic information.",
+      },
+      {
+        name: "List",
+        color: "#C7B1FF",
+        def: "Primarily a list of items rather than prose.",
+      },
+      {
+        name: "Unassessed",
+        color: "#9E9E9E",
+        def: "No quality grade has been assigned yet.",
+      },
+    ],
+  },
+  {
+    title: "Article metrics",
+    terms: [
+      {
+        name: "Average daily views",
+        def: "The average number of times the article is viewed per day over the focus period.",
+      },
+      {
+        name: "Number of editors",
+        def: "The count of distinct editors who have contributed to the article.",
+      },
+      {
+        name: "Incoming links",
+        def: "The number of other Wikipedia articles that link to this one.",
+      },
+      {
+        name: "Article size",
+        def: "The byte size of the article's wikitext content.",
+      },
+      {
+        name: "Lead section size",
+        def: "The byte size of the article's introduction (before the table of contents).",
+      },
+      {
+        name: "Talk / Discussion page size",
+        def: "The byte size of the article's talk page, where editors discuss changes.",
+      },
+      {
+        name: "Images",
+        def: "The number of images embedded in the article.",
+      },
+      {
+        name: "Warning tags",
+        def: 'Maintenance tags flagging quality concerns (e.g., "needs citations").',
+      },
+      {
+        name: "Linguistic versions",
+        def: "The number of other-language Wikipedias with an article on this topic.",
+      },
+      {
+        name: "Centrality",
+        def: "A score (1-10) measuring how central or important an article is to its topic.",
+      },
+      {
+        name: "Publication date",
+        def: "The date the article was first created on Wikipedia.",
+      },
+    ],
+  },
+  {
+    title: "Page protections",
+    intro:
+      "Administrative controls applied to high-traffic or contentious pages.",
+    terms: [
+      {
+        name: "Move restriction",
+        def: "Prevents the article from being renamed except by administrators.",
+      },
+      {
+        name: "Edit restriction",
+        def: "Limits who can edit the article (e.g., semi-protected, extended-confirmed, or fully-protected).",
+      },
+    ],
+  },
+];
+
+interface GlossaryModalProps {
+  onClose: () => void;
+}
+
+const GlossaryModal: React.FC<GlossaryModalProps> = ({ onClose }) => {
+  return (
+    <div
+      className="GlossaryModal"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="Panel">
+        <div className="Header">
+          <div className="TitleGroup">
+            <BsBook size={20} className="HeaderIcon" />
+            <h3 className="Title">Glossary</h3>
+          </div>
+          <button
+            type="button"
+            className="Close"
+            onClick={onClose}
+            aria-label="Close glossary"
+          >
+            <IoClose size={24} />
+          </button>
+        </div>
+        <div className="Body">
+          {GLOSSARY_SECTIONS.map((section) => (
+            <section key={section.title} className="Section">
+              <h4 className="SectionTitle">{section.title}</h4>
+              {section.intro && <p className="SectionIntro">{section.intro}</p>}
+              <dl className="Terms">
+                {section.terms.map((t) => (
+                  <div key={t.name} className="Term">
+                    <dt className="TermName">
+                      {t.color && (
+                        <span
+                          className="TermDot"
+                          style={{ backgroundColor: t.color }}
+                          aria-hidden="true"
+                        />
+                      )}
+                      <span>{t.name}</span>
+                    </dt>
+                    <dd className="TermDef">{t.def}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GlossaryModal;

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -79,22 +79,22 @@ function QualityFilterButtons({
   return (
     <div className="QualityAssessment">
       <div className="BoxTitle">Quality assessment*</div>
-      <div className="QualityFilterGrid">
+      <div className="Grid">
         {gradeGroups.map((g) => {
           const isOn = g.grades.every((x) => selected[x] !== false);
           return (
             <button
               key={g.id}
               type="button"
-              className={`QualityFilterBtn ${isOn ? "is-selected" : ""}`}
+              className={`Btn ${isOn ? "is-selected" : ""}`}
               data-group={g.id}
               onClick={() => onToggle(g.grades, !isOn)}
             >
               <span
-                className="QualityFilterDot"
+                className="Dot"
                 style={{ backgroundColor: g.dot }}
               />
-              <span className="QualityFilterLabel">{g.label}</span>
+              <span className="Label">{g.label}</span>
             </button>
           );
         })}
@@ -117,8 +117,8 @@ function ProtectionFilterCheckboxes({
   return (
     <div className="ProtectionFilter">
       <div className="BoxTitle">Protection filter</div>
-      <div className="ProtectionFilterCheckboxes">
-        <label className="ProtectionFilterLabel">
+      <div className="Checkboxes">
+        <label className="Label">
           <input
             type="checkbox"
             checked={moveChecked}
@@ -126,7 +126,7 @@ function ProtectionFilterCheckboxes({
           />
           <span>Move restriction</span>
         </label>
-        <label className="ProtectionFilterLabel">
+        <label className="Label">
           <input
             type="checkbox"
             checked={editChecked}
@@ -161,9 +161,9 @@ function CentralityFilter({
 
   return (
     <div className="CentralityFilter">
-      <div className="CentralityFilterHeader">
+      <div className="Header">
         <div className="BoxTitle">Centrality</div>
-        <label className="CentralityFilterCheckbox">
+        <label className="Checkbox">
           <input
             type="checkbox"
             checked={includeUnassessed}
@@ -172,14 +172,14 @@ function CentralityFilter({
           />
           <span>include articles without centrality</span>
         </label>
-        <div className="CentralityFilterValue">
+        <div className="Value">
           {min}-{max}
         </div>
       </div>
-      <div className="CentralityFilterSlider">
-        <div className="CentralityFilterTrack" />
+      <div className="Slider">
+        <div className="Track" />
         <div
-          className="CentralityFilterRange"
+          className="Range"
           style={{ left: `${minPercent}%`, right: `${100 - maxPercent}%` }}
         />
         <input
@@ -190,7 +190,7 @@ function CentralityFilter({
           value={min}
           onChange={(e) => onMinChange(Number(e.target.value))}
           aria-label="Minimum centrality"
-          className="CentralityFilterInput CentralityFilterInput--min"
+          className="Input Input--min"
         />
         <input
           type="range"
@@ -200,10 +200,10 @@ function CentralityFilter({
           value={max}
           onChange={(e) => onMaxChange(Number(e.target.value))}
           aria-label="Maximum centrality"
-          className="CentralityFilterInput CentralityFilterInput--max"
+          className="Input Input--max"
         />
       </div>
-      <div className="CentralityFilterBounds">
+      <div className="Bounds">
         <span>{CENTRALITY_MIN}</span>
         <span>{CENTRALITY_MAX}</span>
       </div>
@@ -1089,7 +1089,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
 
   return (
     <div className="WikiBubbleChart">
-      <div className="WikiBubbleChartTitleRow">
+      <div className="TitleRow">
         <h2 className="u-mb0">Article analytics over chosen focus period</h2>
         <CSVButton
           articles={sortedRows}
@@ -1099,17 +1099,17 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         />
       </div>
 
-      <div className="WikiBubbleChartTabBar">
+      <div className="TabBar">
         <button
           type="button"
-          className={`WikiBubbleChartTab ${activeTab === "overview" ? "is-active" : ""}`}
+          className={`Tab ${activeTab === "overview" ? "is-active" : ""}`}
           onClick={() => handleTabChange("overview")}
         >
           Articles overview
         </button>
         <button
           type="button"
-          className={`WikiBubbleChartTab ${activeTab === "languages" ? "is-active" : ""}`}
+          className={`Tab ${activeTab === "languages" ? "is-active" : ""}`}
           onClick={() => handleTabChange("languages")}
         >
           Languages
@@ -1117,29 +1117,29 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       </div>
 
       <div
-        className="WikiBubbleChartTabPanel"
+        className="TabPanel"
         hidden={activeTab !== "overview"}
       >
-        <div className="WikiBubbleChartAxisControls">
-          <div className="WikiBubbleChartFilterBox">
-            <div className="WikiBubbleChartAxisControl">
-              <FaArrowUp size={30} className="WikiBubbleChartAxisIcon" />
-              <div className="WikiBubbleChartAxisFields">
-                <div className="WikiBubbleChartAxisLabelRow">
+        <div className="AxisControls">
+          <div className="FilterBox">
+            <div className="AxisControl">
+              <FaArrowUp size={30} className="AxisIcon" />
+              <div className="AxisFields">
+                <div className="AxisLabelRow">
                   <label htmlFor="wiki-bubble-y-axis" className="BoxTitle">
                     Vertical axis
                   </label>
-                  <div className="WikiBubbleChartScaleToggle">
+                  <div className="ScaleToggle">
                     <button
                       type="button"
-                      className={`WikiBubbleChartScaleBtn ${yAxisScaleType === "linear" ? "is-active" : ""}`}
+                      className={`ScaleBtn ${yAxisScaleType === "linear" ? "is-active" : ""}`}
                       onClick={() => setYAxisScaleType("linear")}
                     >
                       Linear
                     </button>
                     <button
                       type="button"
-                      className={`WikiBubbleChartScaleBtn ${yAxisScaleType === "log" ? "is-active" : ""}`}
+                      className={`ScaleBtn ${yAxisScaleType === "log" ? "is-active" : ""}`}
                       onClick={() => setYAxisScaleType("log")}
                     >
                       Log
@@ -1148,7 +1148,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                 </div>
                 <select
                   id="wiki-bubble-y-axis"
-                  className="WikiBubbleChartSortSelect"
+                  className="SortSelect"
                   value={yAxisKey}
                   onChange={(e) => setYAxisKey(e.target.value as YAxisKey)}
                 >
@@ -1160,13 +1160,13 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             </div>
           </div>
 
-          <div className="WikiBubbleChartFilterBox">
+          <div className="FilterBox">
             <div className="BoxTitle">Y-axis range</div>
-            <div className="WikiBubbleChartRangeRow">
-              <label className="WikiBubbleChartRangeField">
-                <span className="WikiBubbleChartRangeLabel">min</span>
+            <div className="RangeRow">
+              <label className="RangeField">
+                <span className="RangeLabel">min</span>
                 <input
-                  className="WikiBubbleChartRangeInput"
+                  className="RangeInput"
                   type="number"
                   inputMode="numeric"
                   placeholder={
@@ -1179,10 +1179,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                   aria-label="Y-axis minimum"
                 />
               </label>
-              <label className="WikiBubbleChartRangeField">
-                <span className="WikiBubbleChartRangeLabel">max</span>
+              <label className="RangeField">
+                <span className="RangeLabel">max</span>
                 <input
-                  className="WikiBubbleChartRangeInput"
+                  className="RangeInput"
                   type="number"
                   inputMode="numeric"
                   placeholder={
@@ -1198,25 +1198,25 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             </div>
           </div>
 
-          <div className="WikiBubbleChartFilterBox">
-            <div className="WikiBubbleChartAxisControl">
-              <FaArrowRight size={30} className="WikiBubbleChartAxisIcon" />
-              <div className="WikiBubbleChartAxisFields">
-                <div className="WikiBubbleChartAxisLabelRow">
+          <div className="FilterBox">
+            <div className="AxisControl">
+              <FaArrowRight size={30} className="AxisIcon" />
+              <div className="AxisFields">
+                <div className="AxisLabelRow">
                   <label htmlFor="wiki-bubble-sort" className="BoxTitle">
                     Horizontal axis
                   </label>
-                  <div className="WikiBubbleChartScaleToggle">
+                  <div className="ScaleToggle">
                     <button
                       type="button"
-                      className={`WikiBubbleChartScaleBtn ${xAxisMode === "ranked" ? "is-active" : ""}`}
+                      className={`ScaleBtn ${xAxisMode === "ranked" ? "is-active" : ""}`}
                       onClick={() => setXAxisMode("ranked")}
                     >
                       Ranked
                     </button>
                     <button
                       type="button"
-                      className={`WikiBubbleChartScaleBtn ${xAxisMode === "scaled" ? "is-active" : ""}`}
+                      className={`ScaleBtn ${xAxisMode === "scaled" ? "is-active" : ""}`}
                       onClick={() =>
                         xAxisKey !== "title" && setXAxisMode("scaled")
                       }
@@ -1233,7 +1233,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                 </div>
                 <select
                   id="wiki-bubble-sort"
-                  className="WikiBubbleChartSortSelect"
+                  className="SortSelect"
                   value={xAxisKey}
                   onChange={(e) => setXAxisKey(e.target.value as XAxisKey)}
                 >
@@ -1262,7 +1262,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             </div>
           </div>
 
-          <div className="WikiBubbleChartFilterBox">
+          <div className="FilterBox">
             <CentralityFilter
               min={centralityMin}
               max={centralityMax}
@@ -1274,13 +1274,13 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           </div>
         </div>
 
-        <div className="WikiBubbleChartHeading">
-          <div className="WikiBubbleChartInfoLine">
-            <BsInfoCircle size={24} className="WikiBubbleChartInfoIcon" />
+        <div className="Heading">
+          <div className="InfoLine">
+            <BsInfoCircle size={24} className="InfoIcon" />
             <span>See an overview of articles with their statistics</span>
           </div>
-          <div className="WikiBubbleChartHeadingControls">
-            <label className="WikiBubbleChartShowLabels">
+          <div className="HeadingControls">
+            <label className="ShowLabels">
               <input
                 type="checkbox"
                 checked={showLabels}
@@ -1296,8 +1296,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           </div>
         </div>
 
-        <div className="WikiBubbleChartBody">
-          <div className="WikiBubbleChartContainer" ref={containerRef} />
+        <div className="Body">
+          <div className="Container" ref={containerRef} />
           <FilteredArticlesSidebar
             articles={filteredArticles}
             wiki={wiki}
@@ -1307,15 +1307,15 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           />
         </div>
 
-        <div className="WikiBubbleChartQualityFilters">
-          <div className="WikiBubbleChartFilterBox">
+        <div className="QualityFilters">
+          <div className="FilterBox">
             <QualityFilterButtons
               onToggle={toggleGrades}
               selected={selectedGrades}
             />
           </div>
 
-          <div className="WikiBubbleChartFilterBox">
+          <div className="FilterBox">
             <ProtectionFilterCheckboxes
               moveChecked={filterMoveRestriction}
               editChecked={filterEditRestriction}
@@ -1325,16 +1325,16 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           </div>
         </div>
 
-        <div className="WikiBubbleChartStats">
-          <div className="WikiBubbleChartStatCell">
-            <span className="WikiBubbleChartStatValue">
+        <div className="Stats">
+          <div className="StatCell">
+            <span className="StatValue">
               {aggregateStats.totalArticles.toLocaleString()}
             </span>
-            <span className="WikiBubbleChartStatLabel">Total articles</span>
+            <span className="StatLabel">Total articles</span>
           </div>
 
-          <div className="WikiBubbleChartStatCell">
-            <span className="WikiBubbleChartStatValue">
+          <div className="StatCell">
+            <span className="StatValue">
               {aggregateStats.millionVisits !== null
                 ? aggregateStats.millionVisits.toLocaleString("en-US", {
                     minimumFractionDigits: 2,
@@ -1342,7 +1342,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                   })
                 : "—"}
             </span>
-            <span className="WikiBubbleChartStatLabel">
+            <span className="StatLabel">
               Million visits
               {aggregateStats.startDateLabel
                 ? ` (since ${aggregateStats.startDateLabel})`
@@ -1350,54 +1350,54 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             </span>
           </div>
 
-          <div className="WikiBubbleChartStatCell">
-            <span className="WikiBubbleChartStatValue">
+          <div className="StatCell">
+            <span className="StatValue">
               {aggregateStats.averageTotalViews !== null
                 ? aggregateStats.averageTotalViews.toLocaleString()
                 : "—"}
             </span>
-            <span className="WikiBubbleChartStatLabel">
+            <span className="StatLabel">
               Average total views per article
             </span>
           </div>
 
-          <div className="WikiBubbleChartStatCell">
-            <span className="WikiBubbleChartStatValue">
+          <div className="StatCell">
+            <span className="StatValue">
               {aggregateStats.averageArticleSize !== null
                 ? aggregateStats.averageArticleSize.toLocaleString()
                 : "—"}
             </span>
-            <span className="WikiBubbleChartStatLabel">
+            <span className="StatLabel">
               Average article size (bytes)
             </span>
           </div>
         </div>
 
         {/* Legend */}
-        <div className="WikiBubbleChartLegend">
-          <div className="WikiBubbleChartLegendText">
+        <div className="Legend">
+          <div className="Text">
             * Quality assessment is done by the Wikipedia community and it may
             be inconsistent
           </div>
-          <div className="WikiBubbleChartLegendBox">
-            <div className="WikiBubbleChartLegendTitle">Legend</div>
+          <div className="Box">
+            <div className="Title">Legend</div>
             <img src="/images/legend.png" />
           </div>
         </div>
       </div>
 
       <div
-        className="WikiBubbleChartTabPanel"
+        className="TabPanel"
         hidden={activeTab !== "languages"}
       >
-        <div className="WikiBubbleChartQualityFilters">
-          <div className="WikiBubbleChartFilterBox">
+        <div className="QualityFilters">
+          <div className="FilterBox">
             <QualityFilterButtons
               onToggle={toggleGrades}
               selected={selectedGrades}
             />
           </div>
-          <div className="WikiBubbleChartFilterBox">
+          <div className="FilterBox">
             <ProtectionFilterCheckboxes
               moveChecked={filterMoveRestriction}
               editChecked={filterEditRestriction}
@@ -1407,26 +1407,28 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           </div>
         </div>
 
-        <ArticleLanguagesGrid
-          articles={filteredArticles}
-          allArticles={sortedRows}
-          languageLinks={languageLinks}
-          wiki={wiki}
-          loading={langLinksLoading}
-          error={
-            langLinksError
-              ? "Failed to fetch language data. Please try again later."
-              : null
-          }
-          languages={TARGET_LANGUAGES}
-          onArticleClick={setLangCompareArticle}
-          progress={langLinksProgress}
-          topicId={topicId}
-        />
+        <div className="ArticleLang">
+          <ArticleLanguagesGrid
+            articles={filteredArticles}
+            allArticles={sortedRows}
+            languageLinks={languageLinks}
+            wiki={wiki}
+            loading={langLinksLoading}
+            error={
+              langLinksError
+                ? "Failed to fetch language data. Please try again later."
+                : null
+            }
+            languages={TARGET_LANGUAGES}
+            onArticleClick={setLangCompareArticle}
+            progress={langLinksProgress}
+            topicId={topicId}
+          />
 
-        <div className="ArticleLangDisclaimer">
-          * Quality assessment is done by the Wikipedia community and it may be
-          inconsistent
+          <div className="Disclaimer">
+            * Quality assessment is done by the Wikipedia community and it may be
+            inconsistent
+          </div>
         </div>
       </div>
 

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 import vegaEmbed, { VisualizationSpec, EmbedOptions, Result } from "vega-embed";
 import { useQuery } from "@tanstack/react-query";
-import { BsInfoCircle } from "react-icons/bs";
+import { BsBook, BsInfoCircle } from "react-icons/bs";
 import { FaArrowRight, FaArrowUp } from "react-icons/fa6";
 import CSVButton from "./CSV-button.component";
 import ArticleSearchAutocomplete from "./article-search-autocomplete.component";
@@ -16,6 +16,7 @@ import ArticleDetailPanel from "./article-detail-panel.component";
 import FilteredArticlesSidebar from "./filtered-articles-sidebar.component";
 import ArticleLanguagesGrid from "./article-languages-grid.component";
 import ArticleLanguageComparisonModal from "./article-language-comparison-modal.component";
+import GlossaryModal from "./glossary-modal.component";
 import type { ArticleRow } from "./article-detail-panel.component";
 import type {
   ArticleAnalytics,
@@ -90,10 +91,7 @@ function QualityFilterButtons({
               data-group={g.id}
               onClick={() => onToggle(g.grades, !isOn)}
             >
-              <span
-                className="Dot"
-                style={{ backgroundColor: g.dot }}
-              />
+              <span className="Dot" style={{ backgroundColor: g.dot }} />
               <span className="Label">{g.label}</span>
             </button>
           );
@@ -270,6 +268,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   const [langCompareArticle, setLangCompareArticle] = useState<string | null>(
     null,
   );
+  const [glossaryOpen, setGlossaryOpen] = useState<boolean>(false);
   const [showLabels, setShowLabels] = useState<boolean>(false);
   const searchSignalTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -1097,6 +1096,14 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           csvConvert={convertAnalyticsToCSV}
           filename="article-analytics"
         />
+        <button
+          type="button"
+          className="GlossaryBtn"
+          onClick={() => setGlossaryOpen(true)}
+        >
+          <BsBook size={14} />
+          <span>Glossary</span>
+        </button>
       </div>
 
       <div className="TabBar">
@@ -1116,10 +1123,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         </button>
       </div>
 
-      <div
-        className="TabPanel"
-        hidden={activeTab !== "overview"}
-      >
+      <div className="TabPanel" hidden={activeTab !== "overview"}>
         <div className="AxisControls">
           <div className="FilterBox">
             <div className="AxisControl">
@@ -1356,9 +1360,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                 ? aggregateStats.averageTotalViews.toLocaleString()
                 : "—"}
             </span>
-            <span className="StatLabel">
-              Average total views per article
-            </span>
+            <span className="StatLabel">Average total views per article</span>
           </div>
 
           <div className="StatCell">
@@ -1367,9 +1369,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                 ? aggregateStats.averageArticleSize.toLocaleString()
                 : "—"}
             </span>
-            <span className="StatLabel">
-              Average article size (bytes)
-            </span>
+            <span className="StatLabel">Average article size (bytes)</span>
           </div>
         </div>
 
@@ -1386,10 +1386,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         </div>
       </div>
 
-      <div
-        className="TabPanel"
-        hidden={activeTab !== "languages"}
-      >
+      <div className="TabPanel" hidden={activeTab !== "languages"}>
         <div className="QualityFilters">
           <div className="FilterBox">
             <QualityFilterButtons
@@ -1426,8 +1423,18 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           />
 
           <div className="Disclaimer">
-            * Quality assessment is done by the Wikipedia community and it may be
-            inconsistent
+            <span>
+              * Quality assessment is done by the Wikipedia community and it may
+              be inconsistent.
+            </span>
+            <button
+              type="button"
+              className="GlossaryBtn"
+              onClick={() => setGlossaryOpen(true)}
+            >
+              <BsBook size={14} aria-hidden="true" />
+              <span>Glossary</span>
+            </button>
           </div>
         </div>
       </div>
@@ -1449,6 +1456,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           onClose={() => setLangCompareArticle(null)}
         />
       )}
+
+      {glossaryOpen && <GlossaryModal onClose={() => setGlossaryOpen(false)} />}
     </div>
   );
 };

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -1,14 +1,13 @@
-$border-grey:     #d9d9d9;
-$border-light:    #e0e0e0;
-$border-faint:    #eee;
-$primary:         #1976d2;
-$primary-dark:    #1565c0;
-$text-secondary:  #616161;
-$text-muted:      #757575;
-$text-strong:     #424242;
-$danger-bg:       #ffcdd2;
-$danger-fg:       #c62828;
-
+$border-grey: #d9d9d9;
+$border-light: #e0e0e0;
+$border-faint: #eee;
+$primary: #1976d2;
+$primary-dark: #1565c0;
+$text-secondary: #616161;
+$text-muted: #757575;
+$text-strong: #424242;
+$danger-bg: #ffcdd2;
+$danger-fg: #c62828;
 
 .vega-bind-name,
 .BoxTitle {
@@ -16,7 +15,6 @@ $danger-fg:       #c62828;
   font-weight: 600;
   margin-bottom: 6px;
 }
-
 
 .WikiBubbleChart {
   background-color: white;
@@ -440,7 +438,6 @@ $danger-fg:       #c62828;
   }
 }
 
-
 .CentralityFilter {
   display: grid;
   grid-template-rows: auto auto;
@@ -613,7 +610,6 @@ $danger-fg:       #c62828;
   }
 }
 
-
 .QualityAssessment {
   .Title {
     font-weight: 600;
@@ -673,7 +669,6 @@ $danger-fg:       #c62828;
   }
 }
 
-
 .ProtectionFilter {
   display: grid;
   grid-template-rows: auto 1fr;
@@ -717,7 +712,6 @@ $danger-fg:       #c62828;
     }
   }
 }
-
 
 .ArticleSearchAutocomplete {
   position: relative;
@@ -775,7 +769,6 @@ $danger-fg:       #c62828;
     }
   }
 }
-
 
 .ArticleDetail {
   position: fixed;
@@ -1056,9 +1049,21 @@ $danger-fg:       #c62828;
       margin-top: 2px;
       color: #2e7d32;
     }
+
+    .SpinnerWrap {
+      display: flex;
+      justify-content: center;
+      padding: 20px;
+    }
+
+    .Message {
+      font-size: 13px;
+      color: #4a4a4a;
+      font-style: italic;
+      padding: 16px 20px;
+    }
   }
 }
-
 
 .FilteredArticlesSidebar {
   position: relative;
@@ -1239,7 +1244,6 @@ $danger-fg:       #c62828;
     }
   }
 }
-
 
 .ArticleLang {
   .Grid {
@@ -1528,9 +1532,10 @@ $danger-fg:       #c62828;
 }
 
 @keyframes articleLangCellSpin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
-
 
 .ArticleLangComparison {
   position: fixed;

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -213,6 +213,36 @@ $danger-fg:       #c62828;
     align-items: center;
     gap: 12px;
     padding: 12px;
+
+    .GlossaryBtn {
+      margin-left: auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: #f4f8fc;
+      border: 1px solid #cfe0f1;
+      border-radius: 999px;
+      color: #1565c0;
+      cursor: pointer;
+      padding: 6px 14px;
+      font-size: 13px;
+      font-weight: 500;
+      transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+
+      &:hover {
+        background: #e3eef9;
+        border-color: #1565c0;
+        color: #0d47a1;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #1565c0;
+        outline-offset: 2px;
+      }
+    }
   }
 
   .SearchContainer {
@@ -367,6 +397,7 @@ $danger-fg:       #c62828;
     .Title {
       font-weight: bold;
       font-size: 14px;
+      margin-bottom: 8px;
     }
 
     .Text {
@@ -1458,6 +1489,41 @@ $danger-fg:       #c62828;
     font-size: 13px;
     font-style: italic;
     color: $text-muted;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+
+    .GlossaryBtn {
+      margin-left: auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: #f4f8fc;
+      border: 1px solid #cfe0f1;
+      border-radius: 999px;
+      color: #1565c0;
+      cursor: pointer;
+      padding: 6px 14px;
+      font-size: 13px;
+      font-weight: 500;
+      font-style: normal;
+      transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+
+      &:hover {
+        background: #e3eef9;
+        border-color: #1565c0;
+        color: #0d47a1;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #1565c0;
+        outline-offset: 2px;
+      }
+    }
   }
 }
 
@@ -1662,6 +1728,130 @@ $danger-fg:       #c62828;
       background: #b2dfdb;
       border-color: #4db6ac;
       color: #00695c;
+    }
+  }
+}
+
+.GlossaryModal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+
+  .Panel {
+    background: white;
+    width: 640px;
+    max-width: 100%;
+    max-height: 86vh;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid $border-light;
+    border-radius: 8px;
+    overflow: hidden;
+
+    .Header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 16px 24px;
+      border-bottom: 1px solid $border-light;
+
+      .TitleGroup {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .HeaderIcon {
+        color: #1565c0;
+      }
+
+      .Title {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0;
+      }
+
+      .Close {
+        background: none;
+        border: none;
+        cursor: pointer;
+        color: #555;
+        padding: 4px;
+        display: flex;
+        align-items: center;
+      }
+    }
+
+    .Body {
+      flex: 1;
+      display: block;
+      overflow-y: auto;
+      padding: 8px 24px 20px;
+    }
+
+    .Section {
+      padding: 16px 0 4px;
+
+      & + .Section {
+        border-top: 1px solid $border-light;
+      }
+    }
+
+    .SectionTitle {
+      margin: 0 0 4px;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: #1565c0;
+    }
+
+    .SectionIntro {
+      margin: 0 0 12px;
+      font-size: 13px;
+      color: $text-secondary;
+      line-height: 1.5;
+    }
+
+    .Terms {
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .Term {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .TermName {
+      margin: 0;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .TermDot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      flex: 0 0 auto;
+    }
+
+    .TermDef {
+      margin: 0;
+      font-size: 13px;
+      color: $text-secondary;
+      line-height: 1.5;
     }
   }
 }

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -1,3 +1,15 @@
+$border-grey:     #d9d9d9;
+$border-light:    #e0e0e0;
+$border-faint:    #eee;
+$primary:         #1976d2;
+$primary-dark:    #1565c0;
+$text-secondary:  #616161;
+$text-muted:      #757575;
+$text-strong:     #424242;
+$danger-bg:       #ffcdd2;
+$danger-fg:       #c62828;
+
+
 .vega-bind-name,
 .BoxTitle {
   font-size: 14px;
@@ -5,17 +17,18 @@
   margin-bottom: 6px;
 }
 
+
 .WikiBubbleChart {
   background-color: white;
-  border: 1px solid #e0e0e0;
+  border: 1px solid $border-light;
   width: 100%;
 
-  &QualityFilters {
+  .QualityFilters {
     display: grid;
     grid-template-columns: 1fr;
     gap: 1px;
-    background: #d9d9d9;
-    border-top: 1px solid #d9d9d9;
+    background: $border-grey;
+    border-top: 1px solid $border-grey;
     align-items: stretch;
 
     @media (min-width: 768px) {
@@ -23,12 +36,12 @@
     }
   }
 
-  &AxisControls {
+  .AxisControls {
     display: grid;
     grid-template-columns: 1fr;
     gap: 1px;
-    background: #d9d9d9;
-    border-bottom: 1px solid #d9d9d9;
+    background: $border-grey;
+    border-bottom: 1px solid $border-grey;
     align-items: stretch;
 
     @media (min-width: 768px) {
@@ -40,24 +53,24 @@
     }
   }
 
-  &HeaderFilters,
-  &HeaderSearch,
-  &HeaderSort {
+  .HeaderFilters,
+  .HeaderSearch,
+  .HeaderSort {
     background: white;
   }
 
-  &HeaderFilters {
+  .HeaderFilters {
     padding-right: 12px;
   }
 
-  &HeaderExtra {
+  .HeaderExtra {
     background: white;
     display: flex;
     align-items: center;
     justify-content: center;
   }
 
-  &FilterBox {
+  .FilterBox {
     background: white;
     padding: 12px;
     display: flex;
@@ -97,17 +110,17 @@
     }
   }
 
-  &AxisControls &FilterBox {
+  .AxisControls .FilterBox {
     justify-content: flex-start;
     min-width: 0;
   }
 
-  &SortLabel {
+  .SortLabel {
     font-size: 13px;
     font-weight: 500;
   }
 
-  &SortSelect {
+  .SortSelect {
     padding: 4px 8px;
     border-radius: 4px;
     border: 1px solid #cfcfcf;
@@ -116,34 +129,34 @@
     background-color: #fff;
   }
 
-  &AxisIcon {
+  .AxisIcon {
     margin: 16px 10px 0;
   }
 
-  &AxisControl {
+  .AxisControl {
     display: flex;
     align-items: flex-start;
     gap: 10px;
   }
 
-  &AxisFields {
+  .AxisFields {
     display: flex;
     flex-direction: column;
     gap: 4px;
     flex: 1;
   }
 
-  &AxisLabelRow {
+  .AxisLabelRow {
     display: flex;
     align-items: center;
     gap: 8px;
   }
 
-  &ScaleToggle {
+  .ScaleToggle {
     display: flex;
   }
 
-  &ScaleBtn {
+  .ScaleBtn {
     padding: 2px 8px;
     font-size: 12px;
     font-weight: 500;
@@ -159,8 +172,8 @@
     }
 
     &.is-active {
-      background-color: #1976d2;
-      border-color: #1976d2;
+      background-color: $primary;
+      border-color: $primary;
       color: #fff;
     }
 
@@ -170,218 +183,51 @@
     }
   }
 
-  &RangeRow {
+  .RangeRow {
     display: flex;
     gap: 8px;
     align-items: center;
   }
 
-  &RangeField {
+  .RangeField {
     display: flex;
     align-items: center;
     gap: 6px;
     margin-bottom: 0;
   }
 
-  &RangeLabel {
+  .RangeLabel {
     font-size: 12px;
     font-weight: 400;
   }
 
-  &RangeInput {
+  .RangeInput {
     padding: 4px 8px;
     font-size: 13px;
     width: 100%;
   }
 
-  .CentralityFilter {
-    display: grid;
-    grid-template-rows: auto auto;
-    gap: 0;
-    height: 100%;
-
-    &Header {
-      display: flex;
-      align-items: baseline;
-      justify-content: flex-start;
-      gap: 8px;
-
-      .BoxTitle {
-        flex: 0 0 auto;
-      }
-    }
-
-    &Value {
-      margin-left: auto;
-      font-size: 13px;
-      font-weight: 600;
-      font-variant-numeric: tabular-nums;
-      white-space: nowrap;
-    }
-
-    &Slider {
-      position: relative;
-      height: 24px;
-      margin: 3px 0 0;
-    }
-
-    &Track,
-    &Range {
-      position: absolute;
-      top: 50%;
-      height: 4px;
-      border-radius: 999px;
-      transform: translateY(-50%);
-    }
-
-    &Track {
-      left: 0;
-      right: 0;
-      background: #d9d9d9;
-    }
-
-    &Range {
-      background: #1976d2;
-    }
-
-    &Input {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      border: 0;
-      box-shadow: none;
-      margin: 0;
-      outline: none;
-      padding: 0;
-      pointer-events: none;
-      -webkit-appearance: none;
-      appearance: none;
-      background: transparent;
-
-      &:focus,
-      &:focus-visible {
-        border: 0;
-        box-shadow: none;
-        outline: none;
-      }
-
-      &::-webkit-slider-runnable-track {
-        height: 4px;
-        border: 0;
-        box-shadow: none;
-        background: transparent;
-      }
-
-      &::-webkit-slider-thumb {
-        width: 16px;
-        height: 16px;
-        border: 0;
-        box-shadow: none;
-        border-radius: 50%;
-        background: #1976d2;
-        cursor: pointer;
-        pointer-events: auto;
-        margin-top: -6px;
-        -webkit-appearance: none;
-        appearance: none;
-      }
-
-      &::-moz-range-thumb {
-        width: 14px;
-        height: 14px;
-        border: 0;
-        box-shadow: none;
-        border-radius: 50%;
-        background: #1976d2;
-        cursor: pointer;
-        pointer-events: auto;
-        transform: translateY(-5px);
-      }
-
-      &::-moz-range-track {
-        background: transparent;
-        border: 0;
-      }
-
-      &--min {
-        z-index: 2;
-
-        &::-webkit-slider-thumb {
-          transform: translateX(-3px);
-        }
-
-        &::-moz-range-thumb {
-          transform: translate(-3px, -5px);
-        }
-      }
-
-      &--max {
-        z-index: 3;
-
-        &::-webkit-slider-thumb {
-          transform: translateX(3px);
-        }
-
-        &::-moz-range-thumb {
-          transform: translate(3px, -5px);
-        }
-      }
-    }
-
-    &Bounds {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      margin: -3px 0 0;
-      color: #616161;
-      font-size: 11px;
-      line-height: 1;
-
-      span:first-child {
-        transform: translateX(3px);
-      }
-
-      span:last-child {
-        justify-self: end;
-        transform: translateX(3px);
-      }
-    }
-
-    &Checkbox {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      margin-bottom: 0;
-      font-size: 12px;
-      font-weight: 400;
-      line-height: 1.2;
-
-      input {
-        flex: 0 0 auto;
-        width: 13px;
-        height: 13px;
-        margin: 0;
-      }
-    }
-  }
-
-  &TitleRow {
-    border-bottom: 1px solid #d9d9d9;
+  .TitleRow {
+    border-bottom: 1px solid $border-grey;
     display: flex;
     align-items: center;
     gap: 12px;
     padding: 12px;
   }
 
-  &SearchContainer {
+  .SearchContainer {
     display: flex;
   }
 
-  &Container {
+  .Container {
     overflow-y: hidden;
     width: 100%;
+    max-width: none;
+    margin: 0;
+    padding: 0;
   }
 
-  &Heading {
+  .Heading {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -389,17 +235,17 @@
     padding: 8px 12px;
   }
 
-  &HeadingControls {
+  .HeadingControls {
     display: flex;
     align-items: center;
     gap: 10px;
 
-    .ArticleSearchAutocompleteWrapper {
+    .ArticleSearchAutocomplete {
       width: 320px;
     }
   }
 
-  &ShowLabels {
+  .ShowLabels {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -414,7 +260,7 @@
     }
   }
 
-  &InfoLine {
+  .InfoLine {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -422,25 +268,25 @@
     font-style: italic;
   }
 
-  &Body {
+  .Body {
     position: relative;
     display: flex;
   }
 
-  &Stats {
+  .Stats {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 1px;
-    background: #d9d9d9;
-    border-top: 1px solid #d9d9d9;
-    border-bottom: 1px solid #d9d9d9;
+    background: $border-grey;
+    border-top: 1px solid $border-grey;
+    border-bottom: 1px solid $border-grey;
 
     @media (min-width: 768px) {
       grid-template-columns: repeat(4, 1fr);
     }
   }
 
-  &StatCell {
+  .StatCell {
     background: white;
     padding: 14px 16px;
     display: flex;
@@ -449,20 +295,20 @@
     gap: 8px;
   }
 
-  &StatValue {
+  .StatValue {
     font-size: 22px;
     font-weight: 700;
     color: black;
     line-height: 1.1;
   }
 
-  &StatLabel {
+  .StatLabel {
     font-size: 12px;
-    color: #616161;
+    color: $text-secondary;
     line-height: 1.3;
   }
 
-  &Legend {
+  .Legend {
     display: flex;
     justify-content: space-between;
     padding: 8px 12px;
@@ -472,123 +318,330 @@
     align-items: center;
     font-size: 0.9rem;
 
-    &Item {
+    .Item {
       display: flex;
       align-items: center;
       gap: 4px;
     }
 
-    &DotArticle,
-    &DotLead,
-    &RingDiscussion,
-    &RingPrevArticle {
+    .DotArticle,
+    .DotLead,
+    .RingDiscussion,
+    .RingPrevArticle {
       display: inline-block;
       width: 12px;
       height: 12px;
       border-radius: 50%;
     }
 
-    &DotArticle {
+    .DotArticle {
       background-color: rgba(13, 71, 161, 0.5);
     }
 
-    &DotLead {
+    .DotLead {
       background-color: #90caf9;
     }
 
-    &RingDiscussion {
+    .RingDiscussion {
       border: 2px solid #2196f3;
       background-color: transparent;
     }
 
-    &RingPrevArticle {
+    .RingPrevArticle {
       border: 2px dashed #64b5f6;
       background-color: transparent;
     }
 
-    &LineChange {
+    .LineChange {
       display: inline-block;
       width: 16px;
       height: 0;
       border-top: 2px dashed #757575;
     }
 
-    &Box {
+    .Box {
       border: 1px solid #ccc;
       padding: 12px 16px;
     }
 
-    &Title {
+    .Title {
       font-weight: bold;
       font-size: 14px;
     }
 
-    &Text {
+    .Text {
       font-size: 14px;
       font-style: italic;
       align-self: flex-start;
     }
   }
+
+  .TabBar {
+    display: flex;
+    border-bottom: 1px solid $border-grey;
+  }
+
+  .Tab {
+    padding: 10px 24px;
+    font-size: 14px;
+    font-weight: 500;
+    color: $text-muted;
+    background: #f5f5f5;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition:
+      color 120ms ease,
+      background-color 120ms ease,
+      border-color 120ms ease;
+
+    &:hover:not(.is-active) {
+      background: #eeeeee;
+      color: #333;
+    }
+
+    &.is-active {
+      font-weight: 600;
+      color: #000;
+      background: white;
+      border-bottom-color: $primary-dark;
+    }
+  }
 }
 
+
+.CentralityFilter {
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: 0;
+  height: 100%;
+
+  .Header {
+    display: flex;
+    align-items: baseline;
+    justify-content: flex-start;
+    gap: 8px;
+    background: none;
+    border-bottom: none;
+
+    .BoxTitle {
+      flex: 0 0 auto;
+    }
+  }
+
+  .Value {
+    margin-left: auto;
+    font-size: 13px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .Slider {
+    position: relative;
+    height: 24px;
+    margin: 3px 0 0;
+  }
+
+  .Track,
+  .Range {
+    position: absolute;
+    top: 50%;
+    height: 4px;
+    border-radius: 999px;
+    transform: translateY(-50%);
+  }
+
+  .Track {
+    left: 0;
+    right: 0;
+    background: $border-grey;
+  }
+
+  .Range {
+    background: $primary;
+  }
+
+  input[type="range"].Input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    border: 0;
+    box-shadow: none;
+    margin: 0;
+    outline: none;
+    padding: 0;
+    pointer-events: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+
+    &:focus,
+    &:focus-visible {
+      border: 0;
+      box-shadow: none;
+      outline: none;
+    }
+
+    &::-webkit-slider-runnable-track {
+      height: 4px;
+      border: 0;
+      box-shadow: none;
+      background: transparent;
+    }
+
+    &::-webkit-slider-thumb {
+      width: 16px;
+      height: 16px;
+      border: 0;
+      box-shadow: none;
+      border-radius: 50%;
+      background: $primary;
+      cursor: pointer;
+      pointer-events: auto;
+      margin-top: -6px;
+      -webkit-appearance: none;
+      appearance: none;
+    }
+
+    &::-moz-range-thumb {
+      width: 14px;
+      height: 14px;
+      border: 0;
+      box-shadow: none;
+      border-radius: 50%;
+      background: $primary;
+      cursor: pointer;
+      pointer-events: auto;
+      transform: translateY(-5px);
+    }
+
+    &::-moz-range-track {
+      background: transparent;
+      border: 0;
+    }
+
+    &--min {
+      z-index: 2;
+
+      &::-webkit-slider-thumb {
+        transform: translateX(-3px);
+      }
+
+      &::-moz-range-thumb {
+        transform: translate(-3px, -5px);
+      }
+    }
+
+    &--max {
+      z-index: 3;
+
+      &::-webkit-slider-thumb {
+        transform: translateX(3px);
+      }
+
+      &::-moz-range-thumb {
+        transform: translate(3px, -5px);
+      }
+    }
+  }
+
+  .Bounds {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    margin: -3px 0 0;
+    color: $text-secondary;
+    font-size: 11px;
+    line-height: 1;
+
+    span:first-child {
+      transform: translateX(3px);
+    }
+
+    span:last-child {
+      justify-self: end;
+      transform: translateX(3px);
+    }
+  }
+
+  .Checkbox {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 0;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.2;
+
+    input {
+      flex: 0 0 auto;
+      width: 13px;
+      height: 13px;
+      margin: 0;
+    }
+  }
+}
+
+
 .QualityAssessment {
-  &Title {
+  .Title {
     font-weight: 600;
     margin-bottom: 6px;
     font-size: 14px;
   }
-}
 
-.QualityFilterGrid {
-  display: grid;
-  grid-template-columns: repeat(20, minmax(0, 1fr));
-  gap: 8px 12px;
+  .Grid {
+    display: grid;
+    grid-template-columns: repeat(20, minmax(0, 1fr));
+    gap: 8px 12px;
 
-  .QualityFilterBtn:nth-child(-n + 5) {
-    grid-column: span 4;
+    .Btn:nth-child(-n + 5) {
+      grid-column: span 4;
+    }
+
+    .Btn:nth-child(n + 6) {
+      grid-column: span 5;
+    }
   }
 
-  .QualityFilterBtn:nth-child(n + 6) {
-    grid-column: span 5;
+  .Btn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 10px;
+    border: 1px solid $border-grey;
+    border-radius: 6px;
+    background: #fff;
+    cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      border-color 120ms ease,
+      box-shadow 120ms ease;
+
+    &:hover {
+      border-color: #bdbdbd;
+    }
+
+    &.is-selected {
+      background-color: #cfe9e7;
+      border-color: #b6deda;
+    }
+  }
+
+  .Dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    display: inline-block;
+  }
+
+  .Label {
+    font-size: 13px;
   }
 }
 
-.QualityFilterBtn {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  box-sizing: border-box;
-  padding: 6px 10px;
-  border: 1px solid #d9d9d9;
-  border-radius: 6px;
-  background: #fff;
-  cursor: pointer;
-  transition:
-    background-color 120ms ease,
-    border-color 120ms ease,
-    box-shadow 120ms ease;
-
-  &:hover {
-    border-color: #bdbdbd;
-  }
-
-  &.is-selected {
-    background-color: #cfe9e7;
-    border-color: #b6deda;
-  }
-}
-
-.QualityFilterDot {
-  width: 14px;
-  height: 14px;
-  border-radius: 3px;
-  display: inline-block;
-}
-
-.QualityFilterLabel {
-  font-size: 13px;
-}
 
 .ProtectionFilter {
   display: grid;
@@ -599,14 +652,14 @@
     margin-bottom: 6px;
   }
 
-  &Checkboxes {
+  .Checkboxes {
     display: flex;
     flex-direction: row;
     gap: 8px;
     align-self: center;
   }
 
-  &Label {
+  .Label {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -615,7 +668,7 @@
     cursor: pointer;
     padding: 2px 10px;
     margin-bottom: 0;
-    border: 1px solid #d9d9d9;
+    border: 1px solid $border-grey;
     border-radius: 6px;
     background: #fff;
     transition:
@@ -634,21 +687,20 @@
   }
 }
 
-.ArticleSearchAutocomplete {
-  &Wrapper {
-    position: relative;
-    display: flex;
-    align-items: center;
-  }
 
-  &Icon {
+.ArticleSearchAutocomplete {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  .Icon {
     position: absolute;
     left: 8px;
     color: black;
     font-size: 16px;
   }
 
-  &Input {
+  .Input {
     width: 100%;
     padding-left: 28px !important;
 
@@ -657,7 +709,7 @@
     }
   }
 
-  &List {
+  .List {
     position: absolute;
     top: 100%;
     left: 0;
@@ -666,7 +718,7 @@
     padding: 0;
     list-style: none;
     background: #fff;
-    border: 1px solid #d9d9d9;
+    border: 1px solid $border-grey;
     border-top: none;
     border-radius: 0 0 6px 6px;
     max-height: 240px;
@@ -674,7 +726,7 @@
     z-index: 100;
   }
 
-  &Item {
+  .Item {
     padding: 10px 12px;
     font-size: 14px;
     cursor: pointer;
@@ -693,36 +745,35 @@
   }
 }
 
-.ArticleDetail {
-  &PanelBackdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 1000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 
-  &Panel {
+.ArticleDetail {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .Panel {
     background: white;
     width: 90vw;
     height: 85vh;
     display: flex;
     flex-direction: column;
-    border: 1px solid #e0e0e0;
+    border: 1px solid $border-light;
     border-radius: 4px;
     overflow: hidden;
 
-    &Header {
+    .Header {
       display: flex;
       justify-content: space-between;
       align-items: center;
       padding: 12px 20px;
-      border-bottom: 1px solid #e0e0e0;
+      border-bottom: 1px solid $border-light;
     }
 
-    &Title {
+    .Title {
       font-size: 18px;
       font-weight: 600;
       margin: 0;
@@ -731,18 +782,18 @@
       gap: 8px;
     }
 
-    &TitleLink {
+    .TitleLink {
       color: inherit;
       display: flex;
       align-items: center;
       transition: color 120ms ease;
 
       &:hover {
-        color: #1565c0;
+        color: $primary-dark;
       }
     }
 
-    &Close {
+    .Close {
       background: none;
       border: none;
       cursor: pointer;
@@ -762,7 +813,7 @@
       }
     }
 
-    &Body {
+    .Body {
       display: grid;
       grid-template-columns: 1fr 1.6fr 1.4fr;
       flex: 1;
@@ -775,41 +826,41 @@
     }
   }
 
-  &ColBody {
+  .ColBody {
     flex: 1;
     overflow-y: auto;
   }
 
-  &Info {
-    border-right: 1px solid #e0e0e0;
+  .Info {
+    border-right: 1px solid $border-light;
     display: flex;
     flex-direction: column;
     overflow: hidden;
 
-    &Header {
+    .Header {
       font-size: 14px;
       font-weight: 600;
       padding: 12px 16px 8px;
-      border-bottom: 1px solid #e0e0e0;
+      border-bottom: 1px solid $border-light;
     }
 
-    &Section {
+    .Section {
       padding: 12px 16px;
-      border-bottom: 1px solid #e0e0e0;
+      border-bottom: 1px solid $border-light;
 
       &:last-child {
         border-bottom: none;
       }
 
-      &Title {
+      .Title {
         font-size: 13px;
         font-weight: 600;
-        color: #424242;
+        color: $text-strong;
         margin-bottom: 8px;
       }
     }
 
-    &Row {
+    .Row {
       display: flex;
       justify-content: space-between;
       align-items: baseline;
@@ -823,45 +874,47 @@
       }
     }
 
-    &Label {
-      color: #757575;
+    .Label {
+      color: $text-muted;
       flex-shrink: 0;
     }
 
-    &Value {
+    .Value {
       font-weight: 500;
       text-align: right;
     }
   }
 
-  &Content {
-    border-right: 1px solid #e0e0e0;
+  .Content {
+    border-right: 1px solid $border-light;
     display: flex;
     flex-direction: column;
     overflow: hidden;
 
-    &Header {
+    .Header {
+      display: block;
       padding: 12px 16px 8px;
-      border-bottom: 1px solid #e0e0e0;
+      border-bottom: 1px solid $border-light;
     }
 
-    &Title {
+    .Title {
+      display: inline;
       font-size: 14px;
       font-weight: 600;
     }
 
-    &Subtitle {
+    .Subtitle {
       font-size: 13px;
-      color: #757575;
+      color: $text-muted;
       margin-left: 4px;
     }
 
-    &Tabs {
+    .Tabs {
       display: flex;
-      border-bottom: 1px solid #e0e0e0;
+      border-bottom: 1px solid $border-light;
     }
 
-    &Tab {
+    .Tab {
       flex: 1;
       padding: 8px 20px;
       font-size: 13px;
@@ -869,13 +922,13 @@
       border: none;
       border-bottom: 2px solid transparent;
       cursor: pointer;
-      color: #757575;
+      color: $text-muted;
       transition:
         color 120ms ease,
         background-color 120ms ease;
 
       &:first-child {
-        border-right: 1px solid #e0e0e0;
+        border-right: 1px solid $border-light;
       }
 
       &:hover:not(.is-active) {
@@ -886,12 +939,12 @@
         font-weight: 600;
         color: #000;
         background: white;
-        border-bottom-color: #1565c0;
+        border-bottom-color: $primary-dark;
       }
     }
   }
 
-  &WordCloud {
+  .WordCloud {
     padding: 20px 16px;
     display: flex;
     flex-wrap: wrap;
@@ -899,37 +952,37 @@
     align-items: baseline;
     line-height: 1.4;
 
-    &Word {
+    .Word {
       color: #1a237e;
       cursor: default;
       transition: color 100ms ease;
 
       &:hover {
-        color: #1565c0;
+        color: $primary-dark;
       }
     }
 
-    &Spinner {
+    .SpinnerWrap {
       width: 100%;
       display: flex;
       justify-content: center;
       padding-top: 32px;
     }
 
-    &Message {
+    .Message {
       font-size: 13px;
       color: #9e9e9e;
       font-style: italic;
     }
   }
 
-  &Contrib {
+  .Contrib {
     background: #c8f5c2;
     display: flex;
     flex-direction: column;
     overflow: hidden;
 
-    &SectionHeader {
+    .SectionHeader {
       font-size: 14px;
       font-weight: 600;
       padding: 12px 16px 8px;
@@ -937,15 +990,16 @@
       background: white;
     }
 
-    &Header {
+    .Header {
       font-size: 14px;
       font-weight: 500;
       line-height: 1.5;
       padding: 20px;
       border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+      background: none;
     }
 
-    &List {
+    .List {
       list-style: none;
       margin: 0;
       padding: 0;
@@ -953,7 +1007,7 @@
       flex-direction: column;
     }
 
-    &Item {
+    .Item {
       display: flex;
       align-items: flex-start;
       gap: 10px;
@@ -967,12 +1021,13 @@
       }
     }
 
-    &Arrow {
+    .Arrow {
       margin-top: 2px;
       color: #2e7d32;
     }
   }
 }
+
 
 .FilteredArticlesSidebar {
   position: relative;
@@ -989,10 +1044,10 @@
   &.is-open {
     width: 316px;
     min-width: 316px;
-    border: 1px solid #e0e0e0;
+    border: 1px solid $border-light;
   }
 
-  &Toggle {
+  .Toggle {
     position: absolute;
     left: 0;
     width: 36px;
@@ -1014,23 +1069,23 @@
       background: #5a6099;
     }
 
-    &Icon {
+    .Icon {
       color: #fff;
     }
 
-    &Count {
+    .Count {
       font-size: 11px;
       font-weight: 600;
       color: #fff;
     }
   }
 
-  &.is-open &Toggle {
+  &.is-open .Toggle {
     left: 0;
     border-radius: 0;
   }
 
-  &Content {
+  .Content {
     display: flex;
     flex-direction: column;
     width: 280px;
@@ -1045,7 +1100,7 @@
       margin-left 250ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  &.is-open &Content {
+  &.is-open .Content {
     opacity: 1;
     visibility: visible;
     margin-left: 0;
@@ -1053,28 +1108,28 @@
     min-width: 316px;
   }
 
-  &Header {
+  .Header {
     padding: 16px;
     padding-left: 52px;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid $border-light;
     background: #fff;
     display: flex;
     flex-direction: column;
     position: relative;
   }
 
-  &Title {
+  .Title {
     font-size: 14px;
     font-weight: 600;
     color: #333;
   }
 
-  &Count {
+  .Count {
     font-size: 12px;
     color: #666;
   }
 
-  &List {
+  .List {
     overflow-y: auto;
     margin: 0;
     padding: 0;
@@ -1098,7 +1153,7 @@
     }
   }
 
-  &Item {
+  .Item {
     display: flex;
     align-items: center;
     height: 42px;
@@ -1112,13 +1167,13 @@
     &:hover {
       background-color: #f0f4ff;
 
-      .FilteredArticlesSidebarExternalLink {
+      .ExternalLink {
         opacity: 1;
       }
     }
   }
 
-  &Link {
+  .Link {
     flex: 1;
     padding: 12px 8px 12px 16px;
     font-size: 13px;
@@ -1137,7 +1192,7 @@
     }
   }
 
-  &ExternalLink {
+  .ExternalLink {
     flex-shrink: 0;
     display: flex;
     align-items: center;
@@ -1154,188 +1209,255 @@
   }
 }
 
-.WikiBubbleChartTabBar {
-  display: flex;
-  border-bottom: 1px solid #d9d9d9;
-}
 
-.WikiBubbleChartTab {
-  padding: 10px 24px;
-  font-size: 14px;
-  font-weight: 500;
-  color: #757575;
-  background: #f5f5f5;
-  border: none;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-  transition:
-    color 120ms ease,
-    background-color 120ms ease,
-    border-color 120ms ease;
-
-  &:hover:not(.is-active) {
-    background: #eeeeee;
-    color: #333;
+.ArticleLang {
+  .Grid {
+    display: flex;
+    flex-direction: column;
   }
 
-  &.is-active {
-    font-weight: 600;
-    color: #000;
-    background: white;
-    border-bottom-color: #1565c0;
+  .Grid--loading,
+  .Grid--empty,
+  .Grid--error {
+    padding: 48px 24px;
+    text-align: center;
+    color: $text-muted;
+    font-size: 14px;
+    font-style: italic;
   }
-}
 
-.ArticleLangGrid {
-  display: flex;
-  flex-direction: column;
-}
+  .Grid--loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
 
-.ArticleLangGridLoading,
-.ArticleLangGridEmpty,
-.ArticleLangGridError {
-  padding: 48px 24px;
-  text-align: center;
-  color: #757575;
-  font-size: 14px;
-  font-style: italic;
-}
+    .LoadingText {
+      font-size: 14px;
+      color: $text-secondary;
+    }
 
-.ArticleLangGridLoading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-}
+    .Progress {
+      width: 100%;
+      max-width: 360px;
+      height: 8px;
+      background: $border-light;
+      border-radius: 4px;
+      overflow: hidden;
 
-.ArticleLangGridLoadingText {
-  font-size: 14px;
-  color: #616161;
-}
+      .Bar {
+        height: 100%;
+        background: $primary;
+        border-radius: 4px;
+        transition: width 0.3s ease;
+      }
+    }
+  }
 
-.ArticleLangProgressTrack {
-  width: 100%;
-  max-width: 360px;
-  height: 8px;
-  background: #e0e0e0;
-  border-radius: 4px;
-  overflow: hidden;
-}
+  .Grid--error {
+    color: $danger-fg;
+  }
 
-.ArticleLangProgressBar {
-  height: 100%;
-  background: #1976d2;
-  border-radius: 4px;
-  transition: width 0.3s ease;
-}
+  .Table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
 
-.ArticleLangGridError {
-  color: #c62828;
-}
+    th {
+      padding: 12px 16px;
+      font-size: 13px;
+      font-weight: 600;
+      color: $text-strong;
+      text-align: center;
+      background: white;
+      border: 1px solid $border-faint;
+      border-top: 1px solid $border-grey;
+    }
 
-.ArticleLangTable {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
+    tbody tr {
+      border-bottom: 1px solid $border-faint;
 
-  th {
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+
+    .HeaderArticle {
+      text-align: left !important;
+      font-style: italic;
+      font-weight: 500 !important;
+      color: $text-secondary !important;
+
+      .Inner {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+    }
+
+    .HeaderLang {
+      width: 1fr;
+    }
+  }
+
+  .Row {
+    &:hover {
+      background: #f9f9f9;
+    }
+
+    .Title {
+      padding: 14px 16px;
+      font-size: 13px;
+      font-weight: 500;
+      color: #333;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 220px;
+
+      &--clickable {
+        cursor: pointer;
+      }
+    }
+  }
+
+  .Cell {
+    text-align: center;
+    vertical-align: middle;
+    padding: 10px 8px;
+    position: relative;
+
+    &--present {
+      background: white;
+    }
+
+    &--missing {
+      background: $danger-bg;
+
+      .Translate {
+        display: none;
+      }
+
+      &:hover .Translate {
+        display: flex;
+      }
+
+      &:hover .Missing {
+        display: none;
+      }
+    }
+
+    .Dot {
+      display: inline-block;
+      width: 42px;
+      height: 42px;
+    }
+
+    .Bubble {
+      display: inline-block;
+      vertical-align: middle;
+    }
+
+    .Skeleton {
+      display: inline-block;
+      vertical-align: middle;
+
+      &--loading {
+        animation: articleLangCellSpin 1s linear infinite;
+      }
+    }
+
+    .Missing {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      color: $danger-fg;
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    .Translate {
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      padding: 6px 12px;
+      margin: 0 auto;
+      width: fit-content;
+      background: #e0f2f1;
+      border: 1px solid #80cbc4;
+      border-radius: 4px;
+      color: #00695c;
+      font-size: 12px;
+      font-weight: 500;
+      text-decoration: none;
+      cursor: pointer;
+      transition:
+        background-color 120ms ease,
+        border-color 120ms ease;
+
+      &:hover {
+        background: #b2dfdb;
+        border-color: #4db6ac;
+        text-decoration: none;
+        color: #00695c;
+      }
+    }
+  }
+
+  .Pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    padding: 16px 12px;
+    border-top: 1px solid $border-light;
+
+    .Btn {
+      min-width: 32px;
+      height: 32px;
+      padding: 0 8px;
+      border: 1px solid $border-grey;
+      border-radius: 4px;
+      background: white;
+      color: #333;
+      font-size: 13px;
+      cursor: pointer;
+      transition:
+        background-color 100ms ease,
+        border-color 100ms ease;
+
+      &:hover:not(.is-active):not(:disabled) {
+        background: #f0f0f0;
+        border-color: #bdbdbd;
+      }
+
+      &.is-active {
+        background: $primary;
+        border-color: $primary;
+        color: white;
+        font-weight: 600;
+      }
+
+      &:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+      }
+    }
+
+    .Ellipsis {
+      min-width: 24px;
+      text-align: center;
+      color: #999;
+      font-size: 14px;
+    }
+  }
+
+  .Disclaimer {
     padding: 12px 16px;
     font-size: 13px;
-    font-weight: 600;
-    color: #424242;
-    text-align: center;
-    background: white;
-    border: 1px solid #eee;
-    border-top: 1px solid #d9d9d9;
-  }
-
-  tbody tr {
-    border-bottom: 1px solid #eee;
-
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-}
-
-.ArticleLangTableHeaderArticle {
-  text-align: left !important;
-  font-style: italic;
-  font-weight: 500 !important;
-  color: #616161 !important;
-
-  &__inner {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-}
-
-.ArticleLangTableHeaderLang {
-  width: 1fr;
-}
-
-.ArticleLangRow {
-  &:hover {
-    background: #f9f9f9;
-  }
-}
-
-.ArticleLangRowTitle {
-  padding: 14px 16px;
-  font-size: 13px;
-  font-weight: 500;
-  color: #333;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 220px;
-}
-
-.ArticleLangCell {
-  text-align: center;
-  vertical-align: middle;
-  padding: 10px 8px;
-  position: relative;
-
-  &--present {
-    background: white;
-  }
-
-  &--missing {
-    background: #ffcdd2;
-
-    .ArticleLangCellTranslate {
-      display: none;
-    }
-
-    &:hover .ArticleLangCellTranslate {
-      display: flex;
-    }
-
-    &:hover .ArticleLangCellMissing {
-      display: none;
-    }
-  }
-}
-
-.ArticleLangCellDot {
-  display: inline-block;
-  width: 42px;
-  height: 42px;
-}
-
-.ArticleLangCellBubble {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.ArticleLangCellSkeleton {
-  display: inline-block;
-  vertical-align: middle;
-
-  &--loading {
-    animation: articleLangCellSpin 1s linear infinite;
+    font-style: italic;
+    color: $text-muted;
   }
 }
 
@@ -1343,290 +1465,203 @@
   to { transform: rotate(360deg); }
 }
 
-.ArticleLangCellMissing {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  color: #c62828;
-  font-size: 12px;
-  font-weight: 500;
-}
 
-.ArticleLangCellTranslate {
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 6px 12px;
-  margin: 0 auto;
-  width: fit-content;
-  background: #e0f2f1;
-  border: 1px solid #80cbc4;
-  border-radius: 4px;
-  color: #00695c;
-  font-size: 12px;
-  font-weight: 500;
-  text-decoration: none;
-  cursor: pointer;
-  transition:
-    background-color 120ms ease,
-    border-color 120ms ease;
-
-  &:hover {
-    background: #b2dfdb;
-    border-color: #4db6ac;
-    text-decoration: none;
-    color: #00695c;
-  }
-}
-
-.ArticleLangPagination {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 4px;
-  padding: 16px 12px;
-  border-top: 1px solid #e0e0e0;
-}
-
-.ArticleLangPaginationBtn {
-  min-width: 32px;
-  height: 32px;
-  padding: 0 8px;
-  border: 1px solid #d9d9d9;
-  border-radius: 4px;
-  background: white;
-  color: #333;
-  font-size: 13px;
-  cursor: pointer;
-  transition:
-    background-color 100ms ease,
-    border-color 100ms ease;
-
-  &:hover:not(.is-active):not(:disabled) {
-    background: #f0f0f0;
-    border-color: #bdbdbd;
-  }
-
-  &.is-active {
-    background: #1976d2;
-    border-color: #1976d2;
-    color: white;
-    font-weight: 600;
-  }
-
-  &:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-  }
-}
-
-.ArticleLangPaginationEllipsis {
-  min-width: 24px;
-  text-align: center;
-  color: #999;
-  font-size: 14px;
-}
-
-.ArticleLangDisclaimer {
-  padding: 12px 16px;
-  font-size: 13px;
-  font-style: italic;
-  color: #757575;
-}
-
-.ArticleLangRowTitle--clickable {
-  cursor: pointer;
-}
-
-.ArticleLangComparisonBackdrop {
+.ArticleLangComparison {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
-}
 
-.ArticleLangComparisonPanel {
-  background: white;
-  width: 90vw;
-  max-width: 1100px;
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid #e0e0e0;
-  border-radius: 4px;
-  overflow: hidden;
-}
+  .Panel {
+    background: white;
+    width: 90vw;
+    max-width: 1100px;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid $border-light;
+    border-radius: 4px;
+    overflow: hidden;
 
-.ArticleLangComparisonHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 20px;
-  border-bottom: 1px solid #e0e0e0;
-}
+    .Body {
+      flex: 1;
+      overflow: auto;
+      display: flex;
+      flex-direction: column;
+    }
 
-.ArticleLangComparisonTitle {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 0;
-}
+    .Header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 20px;
+      border-bottom: 1px solid $border-light;
 
-.ArticleLangComparisonClose {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #555;
-  padding: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease;
+      .Title {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0;
+      }
 
-  &:hover {
-    background-color: #f0f0f0;
-    color: #000;
-  }
-}
+      .Close {
+        background: none;
+        border: none;
+        cursor: pointer;
+        color: #555;
+        padding: 4px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 4px;
+        transition:
+          background-color 120ms ease,
+          color 120ms ease;
 
-.ArticleLangComparisonLoading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 64px 24px;
-}
-
-.ArticleLangComparisonError {
-  padding: 48px 24px;
-  text-align: center;
-  color: #c62828;
-  font-size: 14px;
-}
-
-.ArticleLangComparisonTable {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-}
-
-.ArticleLangComparisonMetricHeader {
-  width: 200px;
-  background: white;
-  border: 1px solid #eee;
-}
-
-.ArticleLangComparisonLangHeader {
-  padding: 12px 16px;
-  font-size: 13px;
-  font-weight: 600;
-  color: #424242;
-  text-align: center;
-  background: white;
-  border: 1px solid #eee;
-
-  span {
-    margin-right: 4px;
+        &:hover {
+          background-color: #f0f0f0;
+          color: #000;
+        }
+      }
+    }
   }
 
-  &--missing {
-    background: #ffcdd2;
-    color: #c62828;
+  .Loading {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
   }
-}
 
-.ArticleLangComparisonHeaderLink {
-  color: inherit;
-  display: inline-flex;
-  align-items: center;
-  vertical-align: middle;
-
-  &:hover {
-    color: #1565c0;
-  }
-}
-
-.ArticleLangComparisonMetricLabel {
-  padding: 12px 16px;
-  font-size: 13px;
-  font-weight: 500;
-  color: #555;
-  border: 1px solid #eee;
-  background: #fafafa;
-  white-space: nowrap;
-}
-
-.ArticleLangComparisonCell {
-  padding: 10px 12px;
-  border: 1px solid #eee;
-
-  &--missing {
-    background: #ffcdd2;
+  .Error {
+    padding: 48px 24px;
     text-align: center;
+    color: $danger-fg;
+    font-size: 14px;
   }
 
-  &--translate {
-    padding: 8px 12px;
+  .Table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+
+    .MetricHeader {
+      width: 200px;
+      background: white;
+      border: 1px solid $border-faint;
+    }
+
+    .LangHeader {
+      padding: 12px 16px;
+      font-size: 13px;
+      font-weight: 600;
+      color: $text-strong;
+      text-align: center;
+      background: white;
+      border: 1px solid $border-faint;
+
+      span {
+        margin-right: 4px;
+      }
+
+      &--missing {
+        background: $danger-bg;
+        color: $danger-fg;
+      }
+
+      .Link {
+        color: inherit;
+        display: inline-flex;
+        align-items: center;
+        vertical-align: middle;
+
+        &:hover {
+          color: $primary-dark;
+        }
+      }
+    }
+
+    .MetricLabel {
+      padding: 12px 16px;
+      font-size: 13px;
+      font-weight: 500;
+      color: #555;
+      border: 1px solid $border-faint;
+      background: #fafafa;
+      white-space: nowrap;
+    }
+
+    .Cell {
+      padding: 10px 12px;
+      border: 1px solid $border-faint;
+
+      &--missing {
+        background: $danger-bg;
+        text-align: center;
+      }
+
+      &--translate {
+        padding: 8px 12px;
+      }
+
+      .MissingIcon {
+        color: $danger-fg;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .Inner {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+
+        .Value {
+          font-size: 13px;
+          font-weight: 500;
+          color: #333;
+          min-width: 64px;
+          text-align: right;
+        }
+
+        .Track {
+          flex: 1;
+          height: 16px;
+          background: #f0f0f0;
+          border-radius: 2px;
+
+          .Bar {
+            height: 100%;
+            background: #90caf9;
+            border-radius: 2px;
+          }
+        }
+      }
+    }
   }
-}
 
-.ArticleLangComparisonMissingIcon {
-  color: #c62828;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.ArticleLangComparisonCellInner {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.ArticleLangComparisonValue {
-  font-size: 13px;
-  font-weight: 500;
-  color: #333;
-  min-width: 64px;
-  text-align: right;
-}
-
-.ArticleLangComparisonBarTrack {
-  flex: 1;
-  height: 16px;
-  background: #f0f0f0;
-  border-radius: 2px;
-}
-
-.ArticleLangComparisonBar {
-  height: 100%;
-  background: #90caf9;
-  border-radius: 2px;
-}
-
-.ArticleLangComparisonTranslateLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: #e0f2f1;
-  border: 1px solid #80cbc4;
-  border-radius: 4px;
-  color: #00695c;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition:
-    background-color 120ms ease,
-    border-color 120ms ease;
-
-  &:hover {
-    background: #b2dfdb;
-    border-color: #4db6ac;
+  .TranslateLink {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    background: #e0f2f1;
+    border: 1px solid #80cbc4;
+    border-radius: 4px;
     color: #00695c;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      border-color 120ms ease;
+
+    &:hover {
+      background: #b2dfdb;
+      border-color: #4db6ac;
+      color: #00695c;
+    }
   }
 }

--- a/app/frontend/utils/article-quality-utils.ts
+++ b/app/frontend/utils/article-quality-utils.ts
@@ -1,0 +1,95 @@
+// Threshold and feature mapping ported from the Wikimedia microtask-generator:
+// https://gitlab.wikimedia.org/toolforge-repos/microtask-generator/-/blob/main/main.py
+
+export const QUALITY_THRESHOLD = 0.5;
+
+export const QUALITY_CHECKS: { key: string; message: string }[] = [
+  { key: "refs", message: "Add more references" },
+  { key: "wikilinks", message: "Add more internal wikilinks" },
+  { key: "headings", message: "Improve article section headings" },
+  { key: "media", message: "Add images or other media" },
+  { key: "infobox", message: "Add an infobox" },
+  { key: "categories", message: "Add more relevant categories" },
+  {
+    key: "characters",
+    message: "This article is too short, try to expand the content",
+  },
+];
+
+export const MESSAGEBOX_MESSAGE = "Check article for a maintenance message";
+
+type Normalized = Record<string, number | boolean | undefined>;
+type Features = { normalized?: Normalized } | undefined | null;
+
+export function getArticleNeeds(features: Features): string[] {
+  const normalized = features?.normalized;
+  if (!normalized) return [];
+
+  const needs: string[] = [];
+
+  for (const { key, message } of QUALITY_CHECKS) {
+    const score = normalized[key];
+    if (typeof score === "number" && score <= QUALITY_THRESHOLD) {
+      needs.push(message);
+    }
+  }
+
+  if (normalized.messagebox) {
+    needs.push(MESSAGEBOX_MESSAGE);
+  }
+
+  return needs;
+}
+
+async function fetchLatestRevId(
+  title: string,
+  lang: string,
+): Promise<number | null> {
+  const url =
+    `https://${lang}.wikipedia.org/w/api.php?` +
+    `action=query&format=json&prop=revisions&rvprop=ids` +
+    `&titles=${encodeURIComponent(title.replace(/ /g, "_"))}` +
+    `&redirects=1&normalize=1&origin=*`;
+
+  const response = await fetch(url);
+  const data = await response.json();
+  const pages = data?.query?.pages ?? {};
+  const page = Object.values(pages)[0] as
+    | { revisions?: { revid?: number }[] }
+    | undefined;
+  return page?.revisions?.[0]?.revid ?? null;
+}
+
+async function fetchQualityFeatures(
+  revId: number,
+  lang: string,
+): Promise<Features> {
+  const response = await fetch(
+    "https://api.wikimedia.org/service/lw/inference/v1/models/articlequality:predict",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rev_id: revId,
+        lang,
+        extended_output: "true",
+      }),
+    },
+  );
+  const data = await response.json();
+  return data?.features ?? null;
+}
+
+export async function fetchArticleNeeds(
+  title: string,
+  lang: string,
+): Promise<string[]> {
+  try {
+    const revId = await fetchLatestRevId(title, lang);
+    if (revId == null) return [];
+    const features = await fetchQualityFeatures(revId, lang);
+    return getArticleNeeds(features);
+  } catch {
+    return [];
+  }
+}

--- a/app/frontend/utils/word-cloud-utils.ts
+++ b/app/frontend/utils/word-cloud-utils.ts
@@ -234,6 +234,23 @@ const STOPWORDS = new Set([
   "took",
 ]);
 
+export async function fetchArticleWordFrequencies(
+  title: string,
+  lang: string,
+  project: string,
+): Promise<{ word: string; count: number }[]> {
+  const url =
+    `https://${lang}.${project}.org/w/api.php?` +
+    `action=query&prop=extracts&explaintext=true&exsectionformat=plain` +
+    `&titles=${encodeURIComponent(title)}&format=json&origin=*`;
+
+  const response = await fetch(url);
+  const data = await response.json();
+  const pages = data?.query?.pages ?? {};
+  const page = Object.values(pages)[0] as { extract?: string } | undefined;
+  return computeWordFrequencies(page?.extract ?? "");
+}
+
 export function computeWordFrequencies(
   text: string,
   topN = 70,


### PR DESCRIPTION
## Changes
- **New features**
  - Added a new glossary modal accessible from the bubble chart
    - Documents the Wikipedia quality assessment grades (FA, A-Class, GA, B, C, Start, Stub, List, Unassessed) with their associated bubble colors
    - Documents the article metrics used across the chart and detail panel (size, lead section size, talk size, warning tags, images, linguistic versions, centrality, incoming links, average daily views, editors)
  - Replaced the static "Contribution" list in the article detail panel with dynamic article-specific suggestions
    - On panel open, fetches the article's latest revision info
    - Surfaces only the recommendations whose normalized feature score falls below the threshold (refs, wikilinks, headings, media, infobox, categories, characters) plus a maintenance-message item when the article has a messagebox flag
    - Concept based on the [microtask-generator](https://gitlab.wikimedia.org/toolforge-repos/microtask-generator) tool
- **Refactoring**
  - Moved both article-detail-panel fetches (word frequencies + quality needs) onto TanStack Query
  - Moved around some component logic for bubble chart for easier access

## Video

https://github.com/user-attachments/assets/f48011d5-0ab4-4c31-98a5-3fa52ab33bb5

