### PR TITLE
New chart filters and features + code refactoring

### DIFF
--- a/app/frontend/components/filtered-articles-sidebar.component.tsx
+++ b/app/frontend/components/filtered-articles-sidebar.component.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { List } from "react-window";
 import { GoTriangleLeft, GoTriangleRight } from "react-icons/go";
 import { FiExternalLink } from "react-icons/fi";
+import { BsEye, BsEyeSlash } from "react-icons/bs";
 import { getWikiUrl } from "../utils/search-utils";
 import type { ArticleRow } from "./article-detail-panel.component";
 
@@ -14,16 +15,22 @@ interface FilteredArticlesSidebarProps {
   isOpen: boolean;
   onToggle: () => void;
   onArticleClick?: (article: ArticleRow) => void;
+  excludedOutliers?: Set<string>;
+  onToggleOutlier?: (article: string) => void;
+  onClearOutliers?: () => void;
 }
 
 interface SidebarRowProps {
   articles: ArticleRow[];
   wiki?: { language: string; project: string };
   onArticleClick?: (article: ArticleRow) => void;
+  excludedOutliers?: Set<string>;
+  onToggleOutlier?: (article: string) => void;
 }
 
 function SidebarRow(props: SidebarRowProps): React.ReactElement | null {
-  const { articles, wiki, onArticleClick } = props;
+  const { articles, wiki, onArticleClick, excludedOutliers, onToggleOutlier } =
+    props;
   const { index, style } = props as unknown as {
     index: number;
     style: React.CSSProperties;
@@ -31,8 +38,25 @@ function SidebarRow(props: SidebarRowProps): React.ReactElement | null {
   const articleRow = articles[index];
   if (!articleRow) return null;
 
+  const isExcluded = excludedOutliers?.has(articleRow.article) ?? false;
+
   return (
-    <li style={style} className="Item">
+    <li style={style} className={`Item ${isExcluded ? "is-excluded" : ""}`}>
+      {onToggleOutlier && (
+        <button
+          type="button"
+          className={`TrimBtn ${isExcluded ? "is-excluded" : ""}`}
+          onClick={() => onToggleOutlier(articleRow.article)}
+          title={isExcluded ? "Restore to chart" : "Trim from chart"}
+          aria-label={
+            isExcluded
+              ? `Restore ${articleRow.article} to chart`
+              : `Trim ${articleRow.article} from chart`
+          }
+        >
+          {isExcluded ? <BsEyeSlash /> : <BsEye />}
+        </button>
+      )}
       <button
         type="button"
         className="Link"
@@ -57,46 +81,103 @@ function SidebarRow(props: SidebarRowProps): React.ReactElement | null {
 }
 
 const FilteredArticlesSidebar: React.FC<FilteredArticlesSidebarProps> =
-  React.memo(({ articles, wiki, isOpen, onToggle, onArticleClick }) => {
-    return (
-      <div className={`FilteredArticlesSidebar ${isOpen ? "is-open" : ""}`}>
-        <button
-          type="button"
-          className="Toggle"
-          onClick={onToggle}
-          aria-label={isOpen ? "Close sidebar" : "Open sidebar"}
-        >
-          <span className="Icon">
-            {isOpen ? <GoTriangleRight /> : <GoTriangleLeft />}
-          </span>
-          <span className="Count">
-            {articles.length}
-          </span>
-        </button>
-        <div className="Content">
-          <div className="Header">
-            <span className="Title">
-              Filtered Articles
+  React.memo(
+    ({
+      articles,
+      wiki,
+      isOpen,
+      onToggle,
+      onArticleClick,
+      excludedOutliers,
+      onToggleOutlier,
+      onClearOutliers,
+    }) => {
+      const [excludedOnly, setExcludedOnly] = useState<boolean>(false);
+
+      const excludedCount = useMemo(() => {
+        if (!excludedOutliers?.size) return 0;
+        return articles.reduce(
+          (count, row) => count + (excludedOutliers.has(row.article) ? 1 : 0),
+          0,
+        );
+      }, [articles, excludedOutliers]);
+
+      const hasExcluded = excludedCount > 0;
+      const showExcludedOnly = hasExcluded && excludedOnly;
+
+      const displayedArticles = useMemo(() => {
+        if (!showExcludedOnly) return articles;
+        return articles.filter(
+          (row) => excludedOutliers?.has(row.article) ?? false,
+        );
+      }, [articles, showExcludedOnly, excludedOutliers]);
+
+      return (
+        <div className={`FilteredArticlesSidebar ${isOpen ? "is-open" : ""}`}>
+          <button
+            type="button"
+            className="Toggle"
+            onClick={onToggle}
+            aria-label={isOpen ? "Close sidebar" : "Open sidebar"}
+          >
+            <span className="Icon">
+              {isOpen ? <GoTriangleRight /> : <GoTriangleLeft />}
             </span>
-            <span className="Count">
-              {articles.length} article{articles.length !== 1 ? "s" : ""}
-            </span>
+            <span className="Count">{articles.length}</span>
+          </button>
+          <div className="Content">
+            <div className="Header">
+              <div className="HeaderTop">
+                <span className="Title">Filtered Articles</span>
+                <span className="Count">
+                  {displayedArticles.length} article
+                  {displayedArticles.length !== 1 ? "s" : ""}
+                </span>
+              </div>
+              {hasExcluded && (
+                <div className="TrimControls">
+                  <label className="TrimFilter">
+                    <input
+                      type="checkbox"
+                      checked={excludedOnly}
+                      onChange={(e) => setExcludedOnly(e.target.checked)}
+                    />
+                    <span>Excluded only ({excludedCount})</span>
+                  </label>
+                  {onClearOutliers && (
+                    <button
+                      type="button"
+                      className="ClearBtn"
+                      onClick={onClearOutliers}
+                    >
+                      Clear all
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+            {isOpen && (
+              <List
+                className="List"
+                rowComponent={SidebarRow}
+                rowCount={displayedArticles.length}
+                rowHeight={ITEM_HEIGHT}
+                rowProps={{
+                  articles: displayedArticles,
+                  wiki,
+                  onArticleClick,
+                  excludedOutliers,
+                  onToggleOutlier,
+                }}
+                overscanCount={10}
+                style={{ maxHeight: LIST_HEIGHT }}
+              />
+            )}
           </div>
-          {isOpen && (
-            <List
-              className="List"
-              rowComponent={SidebarRow}
-              rowCount={articles.length}
-              rowHeight={ITEM_HEIGHT}
-              rowProps={{ articles, wiki, onArticleClick }}
-              overscanCount={10}
-              style={{ maxHeight: LIST_HEIGHT }}
-            />
-          )}
         </div>
-      </div>
-    );
-  });
+      );
+    },
+  );
 
 FilteredArticlesSidebar.displayName = "FilteredArticlesSidebar";
 

--- a/app/frontend/components/topic-detail.component.tsx
+++ b/app/frontend/components/topic-detail.component.tsx
@@ -284,6 +284,7 @@ function TopicDetail() {
             actions
             wiki={topic.wiki}
             topicId={id}
+            topicName={topic.name}
             topicStartDate={topic.start_date}
             topicEndDate={topic.end_date}
           />
@@ -297,6 +298,7 @@ function TopicDetail() {
             actions
             wiki={topic.wiki}
             topicId={id}
+            topicName={topic.name}
             topicStartDate={topic.start_date}
             topicEndDate={topic.end_date}
           />

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-icons/bs";
 import { FaArrowRight, FaArrowUp } from "react-icons/fa6";
 import CSVButton from "./CSV-button.component";
+import WikitextButton from "./wikitext-button.component";
 import ArticleSearchAutocomplete from "./article-search-autocomplete.component";
 import ArticleDetailPanel from "./article-detail-panel.component";
 import FilteredArticlesSidebar from "./filtered-articles-sidebar.component";
@@ -32,6 +33,7 @@ import type {
 } from "../types/bubble-chart.type";
 import {
   convertAnalyticsToCSV,
+  convertAnalyticsToWikitext,
   getAssessmentColor,
   compareArticlesByPublicationDateAsc,
   compareArticlesByNumericFieldAsc,
@@ -1208,6 +1210,12 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           articles={sortedRows}
           filteredArticles={filteredArticles}
           csvConvert={convertAnalyticsToCSV}
+          filename="article-analytics"
+        />
+        <WikitextButton
+          articles={sortedRows}
+          filteredArticles={filteredArticles}
+          wikitextConvert={convertAnalyticsToWikitext}
           filename="article-analytics"
         />
         <button

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -119,19 +119,32 @@ function QualityFilterButtons({
 function TagFilterButtons({
   tags,
   deselected,
+  includeUntagged,
   onToggle,
   onToggleAll,
+  onIncludeUntaggedChange,
 }: {
   tags: string[];
   deselected: Set<string>;
+  includeUntagged: boolean;
   onToggle: (tag: string, on: boolean) => void;
   onToggleAll: (on: boolean) => void;
+  onIncludeUntaggedChange: (checked: boolean) => void;
 }) {
   const allSelected = deselected.size === 0;
   return (
     <div className="TagFilter">
       <div className="TagFilterHead">
         <div className="BoxTitle">Tags</div>
+        <label className="Checkbox">
+          <input
+            type="checkbox"
+            checked={includeUntagged}
+            onChange={(e) => onIncludeUntaggedChange(e.target.checked)}
+            aria-label="Include untagged articles"
+          />
+          <span>include untagged articles</span>
+        </label>
         <button
           type="button"
           className="ToggleAll"
@@ -292,6 +305,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
 
   const [deselectedTags, setDeselectedTags] = useState<Set<string>>(
     () => new Set(initialState.deselectedTags),
+  );
+  const [includeUntagged, setIncludeUntagged] = useState<boolean>(
+    initialState.includeUntagged,
   );
   const [xAxisKey, setXAxisKey] = useState<XAxisKey>(initialState.xAxisKey);
   const [xAxisMode, setXAxisMode] = useState<"ranked" | "scaled">(
@@ -614,6 +630,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           }
         }
         if (!anySelected) return false;
+      } else if (!includeUntagged) {
+        return false;
       }
 
       return true;
@@ -630,6 +648,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     parsedYAxisDomain,
     yAxisConfig.currentField,
     deselectedTags,
+    includeUntagged,
   ]);
 
   useEffect(() => {
@@ -746,7 +765,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     };
 
     const tagFilterExpr = availableTags.length
-      ? `(length(datum.classifications) == 0 || (${availableTags
+      ? `((length(datum.classifications) == 0 && include_untagged) || (${availableTags
           .map(
             (tag, i) =>
               `(tag_${i} && indexof(datum.classifications, ${JSON.stringify(tag)}) >= 0)`,
@@ -820,6 +839,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           name: `tag_${i}`,
           value: !deselectedTags.has(tag),
         })),
+        { name: "include_untagged", value: includeUntagged },
         {
           name: "y_domain_min",
           value:
@@ -1196,6 +1216,14 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     });
   };
 
+  const handleIncludeUntaggedChange = (checked: boolean) => {
+    if (viewRef.current) {
+      viewRef.current.view.signal("include_untagged", checked);
+      viewRef.current.view.runAsync();
+    }
+    startTransition(() => setIncludeUntagged(checked));
+  };
+
   const handleMoveRestrictionChange = (checked: boolean) => {
     if (viewRef.current) {
       viewRef.current.view.signal("filter_move_restriction", checked);
@@ -1299,6 +1327,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       showLabels,
       selectedGrades,
       deselectedTags: [...deselectedTags],
+      includeUntagged,
       excludedOutliers: [...excludedOutliers],
     });
     const qs = new URLSearchParams(next).toString();
@@ -1623,8 +1652,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               <TagFilterButtons
                 tags={availableTags}
                 deselected={deselectedTags}
+                includeUntagged={includeUntagged}
                 onToggle={toggleTag}
                 onToggleAll={toggleAllTags}
+                onIncludeUntaggedChange={handleIncludeUntaggedChange}
               />
             </div>
           )}
@@ -1712,8 +1743,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               <TagFilterButtons
                 tags={availableTags}
                 deselected={deselectedTags}
+                includeUntagged={includeUntagged}
                 onToggle={toggleTag}
                 onToggleAll={toggleAllTags}
+                onIncludeUntaggedChange={handleIncludeUntaggedChange}
               />
             </div>
           )}

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -299,6 +299,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   const [showLabels, setShowLabels] = useState<boolean>(
     initialState.showLabels,
   );
+  const [excludedOutliers, setExcludedOutliers] = useState<Set<string>>(
+    () => new Set(initialState.excludedOutliers),
+  );
   const [linkCopied, setLinkCopied] = useState<boolean>(false);
   const searchSignalTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -400,11 +403,21 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     return sortedRows.map((row) => row.article);
   }, [sortedRows]);
 
+  // Stable key for the excluded set so it can drive memo/effect deps without
+  // relying on Set identity (which changes on every toggle).
+  const excludedKey = useMemo(
+    () => [...excludedOutliers].sort().join("|"),
+    [excludedOutliers],
+  );
+
   const yAxisAutoDomain = useMemo(() => {
     let min = Infinity;
     let max = -Infinity;
     let found = false;
     for (let i = 0; i < rows.length; i++) {
+      // Trimmed outliers must not stretch the auto domain, otherwise removing
+      // them from the plot would not actually rescale the remaining bubbles.
+      if (excludedOutliers.has(rows[i].article)) continue;
       const v = rows[i][yAxisConfig.currentField];
       if (typeof v === "number" && Number.isFinite(v)) {
         if (v < min) min = v;
@@ -415,7 +428,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     if (!found)
       return { min: null as number | null, max: null as number | null };
     return { min, max };
-  }, [rows, yAxisConfig.currentField]);
+  }, [rows, yAxisConfig.currentField, excludedOutliers]);
 
   const parsedYAxisDomain = useMemo(() => {
     const parsedMin =
@@ -661,6 +674,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       "((grade_FA && datum.assessment_grade == 'FA') || (grade_FL && datum.assessment_grade == 'FL') || (grade_GA && datum.assessment_grade == 'GA') || (grade_A && datum.assessment_grade == 'A') || (grade_B && datum.assessment_grade == 'B') || (grade_C && datum.assessment_grade == 'C') || (grade_Start && datum.assessment_grade == 'Start') || (grade_Stub && datum.assessment_grade == 'Stub') || (grade_List && datum.assessment_grade == 'List') || (grade_Unassessed && !datum.assessment_grade))",
       "((!filter_move_restriction || datum.has_move_restriction) && (!filter_edit_restriction || datum.has_edit_restriction))",
       "((isValid(datum.centrality) && datum.centrality >= centrality_min && datum.centrality <= centrality_max) || (!isValid(datum.centrality) && include_no_centrality))",
+      "(indexof(trimmed_articles, datum.article) < 0)",
     ].join(" && ");
 
     const isLargeDataset = currentSortedRows.length > LARGE_DATASET_THRESHOLD;
@@ -715,6 +729,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         { name: "centrality_min", value: centralityMin },
         { name: "centrality_max", value: centralityMax },
         { name: "include_no_centrality", value: includeNoCentrality },
+        { name: "trimmed_articles", value: [...excludedOutliers] },
         {
           name: "y_domain_min",
           value:
@@ -998,6 +1013,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     yAxisScaleType,
     yAxisAutoDomain.min,
     yAxisAutoDomain.max,
+    excludedKey,
   ]);
 
   useEffect(() => {
@@ -1108,6 +1124,22 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     setShowLabels(checked);
   };
 
+  const handleToggleOutlier = (article: string) => {
+    setExcludedOutliers((prev) => {
+      const next = new Set(prev);
+      if (next.has(article)) {
+        next.delete(article);
+      } else {
+        next.add(article);
+      }
+      return next;
+    });
+  };
+
+  const handleClearOutliers = () => {
+    setExcludedOutliers(new Set());
+  };
+
   const handleSearchChange = (term: string) => {
     setSearchTerm(term);
     if (searchSignalTimerRef.current) {
@@ -1144,6 +1176,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       searchTerm,
       showLabels,
       selectedGrades,
+      excludedOutliers: [...excludedOutliers],
     });
     const qs = new URLSearchParams(next).toString();
     return `${window.location.origin}${window.location.pathname}${
@@ -1453,6 +1486,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             isOpen={sidebarOpen}
             onToggle={() => setSidebarOpen((prev) => !prev)}
             onArticleClick={setSelectedArticle}
+            excludedOutliers={excludedOutliers}
+            onToggleOutlier={handleToggleOutlier}
+            onClearOutliers={handleClearOutliers}
           />
         </div>
 

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -8,7 +8,14 @@ import React, {
 } from "react";
 import vegaEmbed, { VisualizationSpec, EmbedOptions, Result } from "vega-embed";
 import { useQuery } from "@tanstack/react-query";
-import { BsBook, BsInfoCircle } from "react-icons/bs";
+import { useSearchParams } from "react-router-dom";
+import {
+  BsBook,
+  BsInfoCircle,
+  BsImage,
+  BsLink45Deg,
+  BsCheck2,
+} from "react-icons/bs";
 import { FaArrowRight, FaArrowUp } from "react-icons/fa6";
 import CSVButton from "./CSV-button.component";
 import ArticleSearchAutocomplete from "./article-search-autocomplete.component";
@@ -33,6 +40,11 @@ import {
 } from "../utils/bubble-chart-utils";
 import { fetchLanguageLinks, TARGET_LANGUAGES } from "../utils/language-links";
 import type { LangLinksProgress } from "../utils/language-links";
+import { exportChartImage } from "../utils/chart-image-export";
+import {
+  decodeChartState,
+  encodeChartState,
+} from "../utils/bubble-chart-permalink";
 
 type Wiki = {
   language: string;
@@ -44,6 +56,7 @@ interface WikiBubbleChartProps {
   actions?: boolean;
   wiki?: Wiki;
   topicId?: string | number;
+  topicName?: string;
   topicStartDate?: string;
   topicEndDate?: string;
 }
@@ -214,6 +227,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   actions = false,
   wiki,
   topicId,
+  topicName,
   topicStartDate,
   topicEndDate,
 }) => {
@@ -221,43 +235,54 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   const viewRef = useRef<Result | null>(null);
   const sortedRowsRef = useRef<any[]>([]);
   const lastEmbeddedSortedRowsRef = useRef<any[] | null>(null);
+  const [searchParams] = useSearchParams();
+
+  // Parse the shared view from the URL exactly once, so every control below can
+  // initialize straight from it without a URL->state effect (which would loop).
+  const [initialState] = useState(() => decodeChartState(searchParams));
+
   const [selectedGrades, setSelectedGrades] = useState<Record<string, boolean>>(
-    {
-      FA: true,
-      FL: true,
-      A: true,
-      GA: true,
-      B: true,
-      C: true,
-      Start: true,
-      Stub: true,
-      List: true,
-      Unassessed: true,
-    },
+    initialState.selectedGrades,
   );
-  const [xAxisKey, setXAxisKey] = useState<XAxisKey>("title");
-  const [xAxisMode, setXAxisMode] = useState<"ranked" | "scaled">("ranked");
-  const [yAxisKey, setYAxisKey] = useState<YAxisKey>("average_daily_views");
+  const [xAxisKey, setXAxisKey] = useState<XAxisKey>(initialState.xAxisKey);
+  const [xAxisMode, setXAxisMode] = useState<"ranked" | "scaled">(
+    initialState.xAxisMode,
+  );
+  const [yAxisKey, setYAxisKey] = useState<YAxisKey>(initialState.yAxisKey);
   const [yAxisScaleType, setYAxisScaleType] = useState<"linear" | "log">(
-    "linear",
+    initialState.yAxisScaleType,
   );
-  const [yAxisMinInput, setYAxisMinInput] = useState<string>("");
-  const [yAxisMaxInput, setYAxisMaxInput] = useState<string>("");
-  const [committedYAxisMinInput, setCommittedYAxisMinInput] =
-    useState<string>("");
-  const [committedYAxisMaxInput, setCommittedYAxisMaxInput] =
-    useState<string>("");
+  const [yAxisMinInput, setYAxisMinInput] = useState<string>(
+    initialState.yAxisMin,
+  );
+  const [yAxisMaxInput, setYAxisMaxInput] = useState<string>(
+    initialState.yAxisMax,
+  );
+  const [committedYAxisMinInput, setCommittedYAxisMinInput] = useState<string>(
+    initialState.yAxisMin,
+  );
+  const [committedYAxisMaxInput, setCommittedYAxisMaxInput] = useState<string>(
+    initialState.yAxisMax,
+  );
   const yAxisDomainDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const [filterMoveRestriction, setFilterMoveRestriction] =
-    useState<boolean>(false);
-  const [filterEditRestriction, setFilterEditRestriction] =
-    useState<boolean>(false);
-  const [centralityMin, setCentralityMin] = useState<number>(CENTRALITY_MIN);
-  const [centralityMax, setCentralityMax] = useState<number>(CENTRALITY_MAX);
-  const [includeNoCentrality, setIncludeNoCentrality] = useState<boolean>(true);
-  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [filterMoveRestriction, setFilterMoveRestriction] = useState<boolean>(
+    initialState.filterMoveRestriction,
+  );
+  const [filterEditRestriction, setFilterEditRestriction] = useState<boolean>(
+    initialState.filterEditRestriction,
+  );
+  const [centralityMin, setCentralityMin] = useState<number>(
+    initialState.centralityMin,
+  );
+  const [centralityMax, setCentralityMax] = useState<number>(
+    initialState.centralityMax,
+  );
+  const [includeNoCentrality, setIncludeNoCentrality] = useState<boolean>(
+    initialState.includeNoCentrality,
+  );
+  const [searchTerm, setSearchTerm] = useState<string>(initialState.searchTerm);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
   const [selectedArticle, setSelectedArticle] = useState<ArticleRow | null>(
     null,
@@ -269,10 +294,15 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     null,
   );
   const [glossaryOpen, setGlossaryOpen] = useState<boolean>(false);
-  const [showLabels, setShowLabels] = useState<boolean>(false);
+  const [showLabels, setShowLabels] = useState<boolean>(
+    initialState.showLabels,
+  );
+  const [linkCopied, setLinkCopied] = useState<boolean>(false);
   const searchSignalTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const linkCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevYAxisKeyRef = useRef<YAxisKey>(initialState.yAxisKey);
 
   const yAxisConfig = useMemo(() => {
     switch (yAxisKey) {
@@ -512,6 +542,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   ]);
 
   useEffect(() => {
+    // Only clear the range on a genuine y-axis change. Skipping the no-op mount
+    // run (and any StrictMode re-run) keeps a y-range restored from the URL.
+    if (prevYAxisKeyRef.current === yAxisKey) return;
+    prevYAxisKeyRef.current = yAxisKey;
     setYAxisMinInput("");
     setYAxisMaxInput("");
     setCommittedYAxisMinInput("");
@@ -1000,6 +1034,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       if (searchSignalTimerRef.current) {
         clearTimeout(searchSignalTimerRef.current);
       }
+      if (linkCopiedTimerRef.current) {
+        clearTimeout(linkCopiedTimerRef.current);
+      }
     };
   }, []);
 
@@ -1086,6 +1123,83 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     setActiveTab(tab);
   };
 
+  // Build a shareable URL from the current view on demand. The query string
+  // encodes the controls; pathname + hash are preserved so the parent's
+  // hash-driven view selection (e.g. #bubble) survives.
+  const buildPermalink = () => {
+    const next = encodeChartState({
+      xAxisKey,
+      xAxisMode,
+      yAxisKey,
+      yAxisScaleType,
+      yAxisMin: committedYAxisMinInput,
+      yAxisMax: committedYAxisMaxInput,
+      filterMoveRestriction,
+      filterEditRestriction,
+      centralityMin,
+      centralityMax,
+      includeNoCentrality,
+      searchTerm,
+      showLabels,
+      selectedGrades,
+    });
+    const qs = new URLSearchParams(next).toString();
+    return `${window.location.origin}${window.location.pathname}${
+      qs ? `?${qs}` : ""
+    }${window.location.hash}`;
+  };
+
+  const handleSaveImage = async () => {
+    if (!viewRef.current) return;
+    const formatDate = (value?: string) =>
+      value
+        ? new Date(value).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })
+        : null;
+    const start = formatDate(topicStartDate);
+    const end = formatDate(topicEndDate);
+    const dateRangeLabel = start ? `${start} - ${end ?? "now"}` : null;
+    const generatedLabel = `Generated ${new Date().toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })}`;
+    const safeName =
+      (topicName ?? "article-analytics")
+        .replace(/[^\w-]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "article-analytics";
+
+    try {
+      await exportChartImage({
+        view: viewRef.current.view,
+        logoSrc: "/images/logo.png",
+        title: topicName ?? "Article analytics",
+        dateRangeLabel,
+        generatedLabel,
+        permalink: buildPermalink(),
+        filename: `${safeName}-chart`,
+      });
+    } catch (err) {
+      console.error("Failed to export chart image", err);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(buildPermalink());
+      setLinkCopied(true);
+      if (linkCopiedTimerRef.current) {
+        clearTimeout(linkCopiedTimerRef.current);
+      }
+      linkCopiedTimerRef.current = setTimeout(() => setLinkCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy link", err);
+    }
+  };
+
   return (
     <div className="WikiBubbleChart">
       <div className="TitleRow">
@@ -1096,6 +1210,29 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           csvConvert={convertAnalyticsToCSV}
           filename="article-analytics"
         />
+        <button
+          type="button"
+          className="ShareBtn"
+          onClick={handleSaveImage}
+          disabled={!hasData}
+          title="Download the current chart as a PNG with credits"
+        >
+          <BsImage size={14} aria-hidden="true" />
+          <span>Save image</span>
+        </button>
+        <button
+          type="button"
+          className="ShareBtn"
+          onClick={handleCopyLink}
+          title="Copy a link to this exact chart view"
+        >
+          {linkCopied ? (
+            <BsCheck2 size={16} aria-hidden="true" />
+          ) : (
+            <BsLink45Deg size={16} aria-hidden="true" />
+          )}
+          <span>{linkCopied ? "Copied" : "Copy link"}</span>
+        </button>
         <button
           type="button"
           className="GlossaryBtn"

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -116,6 +116,49 @@ function QualityFilterButtons({
   );
 }
 
+function TagFilterButtons({
+  tags,
+  deselected,
+  onToggle,
+  onToggleAll,
+}: {
+  tags: string[];
+  deselected: Set<string>;
+  onToggle: (tag: string, on: boolean) => void;
+  onToggleAll: (on: boolean) => void;
+}) {
+  const allSelected = deselected.size === 0;
+  return (
+    <div className="TagFilter">
+      <div className="TagFilterHead">
+        <div className="BoxTitle">Tags</div>
+        <button
+          type="button"
+          className="ToggleAll"
+          onClick={() => onToggleAll(!allSelected)}
+        >
+          {allSelected ? "Deselect all" : "Select all"}
+        </button>
+      </div>
+      <div className="Grid">
+        {tags.map((tag) => {
+          const isOn = !deselected.has(tag);
+          return (
+            <button
+              key={tag}
+              type="button"
+              className={`Btn ${isOn ? "is-selected" : ""}`}
+              onClick={() => onToggle(tag, !isOn)}
+            >
+              <span className="Label">{tag}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function ProtectionFilterCheckboxes({
   moveChecked,
   editChecked,
@@ -246,6 +289,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   const [selectedGrades, setSelectedGrades] = useState<Record<string, boolean>>(
     initialState.selectedGrades,
   );
+
+  const [deselectedTags, setDeselectedTags] = useState<Set<string>>(
+    () => new Set(initialState.deselectedTags),
+  );
   const [xAxisKey, setXAxisKey] = useState<XAxisKey>(initialState.xAxisKey);
   const [xAxisMode, setXAxisMode] = useState<"ranked" | "scaled">(
     initialState.xAxisMode,
@@ -346,6 +393,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         return {
           article,
           ...analytics,
+          classifications: analytics?.classifications ?? [],
           assessment_grade_color: getAssessmentColor(
             analytics?.assessment_grade,
           ),
@@ -357,6 +405,21 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     }
     return [];
   }, [data]);
+
+  const availableTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const row of rows) {
+      for (const tag of row.classifications) set.add(tag);
+    }
+    return [...set].sort();
+  }, [rows]);
+
+  // Stable dependency so the Vega spec rebuilds only when the tag set changes,
+  // not on every tag toggle (toggles are signal-driven, like grades).
+  const availableTagsKey = useMemo(
+    () => availableTags.join("|"),
+    [availableTags],
+  );
 
   const sortedRows = useMemo(() => {
     if (!rows.length) return [];
@@ -541,6 +604,18 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         return false;
       }
 
+      const rowTags = row.classifications ?? [];
+      if (rowTags.length > 0) {
+        let anySelected = false;
+        for (const tag of rowTags) {
+          if (!deselectedTags.has(tag)) {
+            anySelected = true;
+            break;
+          }
+        }
+        if (!anySelected) return false;
+      }
+
       return true;
     });
   }, [
@@ -554,6 +629,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     includeNoCentrality,
     parsedYAxisDomain,
     yAxisConfig.currentField,
+    deselectedTags,
   ]);
 
   useEffect(() => {
@@ -669,12 +745,22 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       scale: yScaleSpec,
     };
 
+    const tagFilterExpr = availableTags.length
+      ? `(length(datum.classifications) == 0 || (${availableTags
+          .map(
+            (tag, i) =>
+              `(tag_${i} && indexof(datum.classifications, ${JSON.stringify(tag)}) >= 0)`,
+          )
+          .join(" || ")}))`
+      : "true";
+
     const visibilityFilterExpr = [
       "(!search_input || indexof(lower(datum.article), search_input) >= 0)",
       "((grade_FA && datum.assessment_grade == 'FA') || (grade_FL && datum.assessment_grade == 'FL') || (grade_GA && datum.assessment_grade == 'GA') || (grade_A && datum.assessment_grade == 'A') || (grade_B && datum.assessment_grade == 'B') || (grade_C && datum.assessment_grade == 'C') || (grade_Start && datum.assessment_grade == 'Start') || (grade_Stub && datum.assessment_grade == 'Stub') || (grade_List && datum.assessment_grade == 'List') || (grade_Unassessed && !datum.assessment_grade))",
       "((!filter_move_restriction || datum.has_move_restriction) && (!filter_edit_restriction || datum.has_edit_restriction))",
       "((isValid(datum.centrality) && datum.centrality >= centrality_min && datum.centrality <= centrality_max) || (!isValid(datum.centrality) && include_no_centrality))",
       "(indexof(trimmed_articles, datum.article) < 0)",
+      tagFilterExpr,
     ].join(" && ");
 
     const isLargeDataset = currentSortedRows.length > LARGE_DATASET_THRESHOLD;
@@ -730,6 +816,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         { name: "centrality_max", value: centralityMax },
         { name: "include_no_centrality", value: includeNoCentrality },
         { name: "trimmed_articles", value: [...excludedOutliers] },
+        ...availableTags.map((tag, i) => ({
+          name: `tag_${i}`,
+          value: !deselectedTags.has(tag),
+        })),
         {
           name: "y_domain_min",
           value:
@@ -1014,6 +1104,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     yAxisAutoDomain.min,
     yAxisAutoDomain.max,
     excludedKey,
+    availableTagsKey,
   ]);
 
   useEffect(() => {
@@ -1071,6 +1162,37 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         });
         return next;
       });
+    });
+  };
+
+  const toggleTag = (tag: string, on: boolean) => {
+    const index = availableTags.indexOf(tag);
+    if (viewRef.current && index >= 0) {
+      viewRef.current.view.signal(`tag_${index}`, on);
+      viewRef.current.view.runAsync();
+    }
+    startTransition(() => {
+      setDeselectedTags((prev) => {
+        const next = new Set(prev);
+        if (on) {
+          next.delete(tag);
+        } else {
+          next.add(tag);
+        }
+        return next;
+      });
+    });
+  };
+
+  const toggleAllTags = (on: boolean) => {
+    if (viewRef.current) {
+      availableTags.forEach((_tag, i) =>
+        viewRef.current!.view.signal(`tag_${i}`, on),
+      );
+      viewRef.current.view.runAsync();
+    }
+    startTransition(() => {
+      setDeselectedTags(on ? new Set() : new Set(availableTags));
     });
   };
 
@@ -1176,6 +1298,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       searchTerm,
       showLabels,
       selectedGrades,
+      deselectedTags: [...deselectedTags],
       excludedOutliers: [...excludedOutliers],
     });
     const qs = new URLSearchParams(next).toString();
@@ -1492,7 +1615,20 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           />
         </div>
 
-        <div className="QualityFilters">
+        <div
+          className={`QualityFilters ${availableTags.length ? "has-tags" : ""}`}
+        >
+          {availableTags.length > 0 && (
+            <div className="FilterBox FilterBox--tags">
+              <TagFilterButtons
+                tags={availableTags}
+                deselected={deselectedTags}
+                onToggle={toggleTag}
+                onToggleAll={toggleAllTags}
+              />
+            </div>
+          )}
+
           <div className="FilterBox">
             <QualityFilterButtons
               onToggle={toggleGrades}
@@ -1568,7 +1704,19 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       </div>
 
       <div className="TabPanel" hidden={activeTab !== "languages"}>
-        <div className="QualityFilters">
+        <div
+          className={`QualityFilters ${availableTags.length ? "has-tags" : ""}`}
+        >
+          {availableTags.length > 0 && (
+            <div className="FilterBox FilterBox--tags">
+              <TagFilterButtons
+                tags={availableTags}
+                deselected={deselectedTags}
+                onToggle={toggleTag}
+                onToggleAll={toggleAllTags}
+              />
+            </div>
+          )}
           <div className="FilterBox">
             <QualityFilterButtons
               onToggle={toggleGrades}

--- a/app/frontend/components/wikitext-button.component.tsx
+++ b/app/frontend/components/wikitext-button.component.tsx
@@ -1,0 +1,92 @@
+import React, { RefObject, useCallback, useState } from "react";
+import { downloadAsTXT } from "../utils/search-utils";
+import useOutsideClick from "../hooks/useOutsideClick";
+
+interface WikitextButtonProps<T extends unknown[]> {
+  articles: T;
+  filteredArticles?: T;
+  wikitextConvert: (articles: T) => string;
+  filename: string;
+}
+
+export default function WikitextButton<T extends unknown[]>({
+  articles,
+  filteredArticles,
+  wikitextConvert,
+  filename,
+}: WikitextButtonProps<T>) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+  const wrapperRef = useOutsideClick(closeMenu);
+
+  const runExport = (scope: T, suffix: string) => {
+    downloadAsTXT(wikitextConvert(scope), `${filename}${suffix}`);
+  };
+
+  if (!filteredArticles) {
+    return (
+      <button onClick={() => runExport(articles, "")} className="ExportButton">
+        Export to Wikitext
+      </button>
+    );
+  }
+
+  const totalCount = articles.length;
+  const filteredCount = filteredArticles.length;
+  const filteredIsRedundant = filteredCount === totalCount;
+  const filteredIsEmpty = filteredCount === 0;
+  const filteredDisabled = filteredIsRedundant || filteredIsEmpty;
+
+  let filteredHint: string | undefined;
+  if (filteredIsEmpty) filteredHint = "No articles match the current filters";
+  else if (filteredIsRedundant) filteredHint = "Same as all articles";
+
+  return (
+    <div
+      className="ExportButtonGroup"
+      ref={wrapperRef as RefObject<HTMLDivElement>}
+    >
+      <button
+        type="button"
+        className="ExportButton"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={() => setMenuOpen((v) => !v)}
+      >
+        Export to Wikitext
+        <span className="ExportButtonCaret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      {menuOpen && (
+        <div role="menu" className="ExportButtonMenu">
+          <button
+            type="button"
+            role="menuitem"
+            className="ExportButtonMenuItem"
+            onClick={() => {
+              runExport(articles, "");
+              setMenuOpen(false);
+            }}
+          >
+            All articles ({totalCount.toLocaleString()})
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="ExportButtonMenuItem"
+            disabled={filteredDisabled}
+            title={filteredHint}
+            onClick={() => {
+              if (filteredDisabled) return;
+              runExport(filteredArticles, "-filtered");
+              setMenuOpen(false);
+            }}
+          >
+            Filtered articles ({filteredCount.toLocaleString()})
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -212,8 +212,8 @@ $danger-fg: #c62828;
     gap: 12px;
     padding: 12px;
 
+    .ShareBtn,
     .GlossaryBtn {
-      margin-left: auto;
       display: inline-flex;
       align-items: center;
       gap: 6px;
@@ -240,6 +240,15 @@ $danger-fg: #c62828;
         outline: 2px solid #1565c0;
         outline-offset: 2px;
       }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
+
+    .GlossaryBtn {
+      margin-left: auto;
     }
   }
 

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -32,6 +32,12 @@ $danger-fg: #c62828;
     @media (min-width: 768px) {
       grid-template-columns: 1fr 1fr;
     }
+
+    &.has-tags {
+      @media (min-width: 768px) {
+        grid-template-columns: 1fr 2fr 1fr;
+      }
+    }
   }
 
   .AxisControls {
@@ -719,6 +725,68 @@ $danger-fg: #c62828;
       cursor: pointer;
       border-radius: 6px;
     }
+  }
+}
+
+.TagFilter {
+  .TagFilterHead {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 6px;
+
+    .BoxTitle {
+      margin-bottom: 0;
+    }
+  }
+
+  .ToggleAll {
+    border: none;
+    background: none;
+    padding: 0;
+    font-size: 12px;
+    color: #2a6f6a;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .Grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    max-height: 76px;
+    overflow-y: auto;
+  }
+
+  .Btn {
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 6px 10px;
+    border: 1px solid $border-grey;
+    border-radius: 6px;
+    background: #fff;
+    cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      border-color 120ms ease;
+
+    &:hover {
+      border-color: #bdbdbd;
+    }
+
+    &.is-selected {
+      background-color: #cfe9e7;
+      border-color: #b6deda;
+    }
+  }
+
+  .Label {
+    font-size: 13px;
   }
 }
 

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -732,16 +732,34 @@ $danger-fg: #c62828;
   .TagFilterHead {
     display: flex;
     align-items: baseline;
-    justify-content: space-between;
+    justify-content: flex-start;
     gap: 12px;
     margin-bottom: 6px;
 
     .BoxTitle {
+      flex: 0 0 auto;
       margin-bottom: 0;
     }
   }
 
+  .Checkbox {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 0;
+    font-size: 12px;
+    font-weight: 400;
+
+    input {
+      flex: 0 0 auto;
+      width: 13px;
+      height: 13px;
+      margin: 0;
+    }
+  }
+
   .ToggleAll {
+    margin-left: auto;
     border: none;
     background: none;
     padding: 0;

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -1154,13 +1154,22 @@ $danger-fg: #c62828;
   }
 
   .Header {
-    padding: 16px;
-    padding-left: 52px;
+    min-height: 72px;
+    box-sizing: border-box;
+    padding: 12px 16px 12px 52px;
     border-bottom: 1px solid $border-light;
     background: #fff;
     display: flex;
     flex-direction: column;
+    justify-content: center;
     position: relative;
+  }
+
+  .HeaderTop {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
   }
 
   .Title {
@@ -1172,6 +1181,45 @@ $danger-fg: #c62828;
   .Count {
     font-size: 12px;
     color: #666;
+    white-space: nowrap;
+  }
+
+  .TrimControls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 6px;
+  }
+
+  .TrimFilter {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 400;
+    color: #444;
+    cursor: pointer;
+    margin-bottom: 0;
+
+    input[type="checkbox"] {
+      cursor: pointer;
+    }
+  }
+
+  .ClearBtn {
+    padding: 0;
+    font-size: 12px;
+    font-weight: 500;
+    color: $primary;
+    background: none;
+    border: none;
+    cursor: pointer;
+    white-space: nowrap;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .List {
@@ -1251,6 +1299,34 @@ $danger-fg: #c62828;
     &:hover {
       color: #676eb4;
     }
+  }
+
+  .TrimBtn {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    padding: 8px 4px 8px 14px;
+    background: none;
+    border: none;
+    color: #c2c2c2;
+    cursor: pointer;
+    transition: color 120ms ease;
+
+    &:hover {
+      color: #676eb4;
+    }
+
+    &.is-excluded {
+      color: $primary;
+    }
+  }
+
+  .TrimBtn + .Link {
+    padding-left: 8px;
+  }
+
+  .Item.is-excluded .Link {
+    color: #999;
   }
 }
 

--- a/app/frontend/types/bubble-chart.type.tsx
+++ b/app/frontend/types/bubble-chart.type.tsx
@@ -21,6 +21,7 @@ type ArticleAnalytics = {
   assessment_grade: string | null;
   publication_date: string | null;
   article_protections: ArticleProtection[];
+  classifications?: string[];
 };
 
 type NumericSortField =

--- a/app/frontend/utils/bubble-chart-permalink.ts
+++ b/app/frontend/utils/bubble-chart-permalink.ts
@@ -15,6 +15,7 @@ export interface ChartUiState {
   searchTerm: string;
   showLabels: boolean;
   selectedGrades: Record<string, boolean>;
+  deselectedTags: string[];
   excludedOutliers: string[];
 }
 
@@ -65,6 +66,7 @@ export const DEFAULT_CHART_UI_STATE: ChartUiState = {
   searchTerm: "",
   showLabels: false,
   selectedGrades: Object.fromEntries(GRADE_KEYS.map((g) => [g, true])),
+  deselectedTags: [],
   excludedOutliers: [],
 };
 
@@ -95,6 +97,11 @@ export function encodeChartState(state: ChartUiState): Record<string, string> {
     const off = GRADE_KEYS.filter((g) => state.selectedGrades[g] === false);
     if (off.length) params.off = off.join(",");
   }
+
+  // Tags are all-selected by default, so (like grades) we encode only the ones
+  // the user turned off.
+  if (state.deselectedTags.length)
+    params.tagsoff = state.deselectedTags.join(",");
 
   if (state.excludedOutliers.length)
     params.trim = state.excludedOutliers.join("|");
@@ -167,6 +174,9 @@ export function decodeChartState(params: URLSearchParams): ChartUiState {
       if (offSet.has(g)) state.selectedGrades[g] = false;
     }
   }
+
+  const tagsoff = params.get("tagsoff");
+  state.deselectedTags = tagsoff ? tagsoff.split(",").filter(Boolean) : [];
 
   const trim = params.get("trim");
   state.excludedOutliers = trim ? trim.split("|").filter(Boolean) : [];

--- a/app/frontend/utils/bubble-chart-permalink.ts
+++ b/app/frontend/utils/bubble-chart-permalink.ts
@@ -15,6 +15,7 @@ export interface ChartUiState {
   searchTerm: string;
   showLabels: boolean;
   selectedGrades: Record<string, boolean>;
+  excludedOutliers: string[];
 }
 
 const CENTRALITY_MIN = 1;
@@ -64,6 +65,7 @@ export const DEFAULT_CHART_UI_STATE: ChartUiState = {
   searchTerm: "",
   showLabels: false,
   selectedGrades: Object.fromEntries(GRADE_KEYS.map((g) => [g, true])),
+  excludedOutliers: [],
 };
 
 function allGradesOn(selected: Record<string, boolean>): boolean {
@@ -93,6 +95,9 @@ export function encodeChartState(state: ChartUiState): Record<string, string> {
     const off = GRADE_KEYS.filter((g) => state.selectedGrades[g] === false);
     if (off.length) params.off = off.join(",");
   }
+
+  if (state.excludedOutliers.length)
+    params.trim = state.excludedOutliers.join("|");
 
   return params;
 }
@@ -162,6 +167,9 @@ export function decodeChartState(params: URLSearchParams): ChartUiState {
       if (offSet.has(g)) state.selectedGrades[g] = false;
     }
   }
+
+  const trim = params.get("trim");
+  state.excludedOutliers = trim ? trim.split("|").filter(Boolean) : [];
 
   return state;
 }

--- a/app/frontend/utils/bubble-chart-permalink.ts
+++ b/app/frontend/utils/bubble-chart-permalink.ts
@@ -16,6 +16,7 @@ export interface ChartUiState {
   showLabels: boolean;
   selectedGrades: Record<string, boolean>;
   deselectedTags: string[];
+  includeUntagged: boolean;
   excludedOutliers: string[];
 }
 
@@ -67,6 +68,7 @@ export const DEFAULT_CHART_UI_STATE: ChartUiState = {
   showLabels: false,
   selectedGrades: Object.fromEntries(GRADE_KEYS.map((g) => [g, true])),
   deselectedTags: [],
+  includeUntagged: true,
   excludedOutliers: [],
 };
 
@@ -102,6 +104,8 @@ export function encodeChartState(state: ChartUiState): Record<string, string> {
   // the user turned off.
   if (state.deselectedTags.length)
     params.tagsoff = state.deselectedTags.join(",");
+
+  if (!state.includeUntagged) params.untag = "0";
 
   if (state.excludedOutliers.length)
     params.trim = state.excludedOutliers.join("|");
@@ -177,6 +181,8 @@ export function decodeChartState(params: URLSearchParams): ChartUiState {
 
   const tagsoff = params.get("tagsoff");
   state.deselectedTags = tagsoff ? tagsoff.split(",").filter(Boolean) : [];
+
+  state.includeUntagged = params.get("untag") !== "0";
 
   const trim = params.get("trim");
   state.excludedOutliers = trim ? trim.split("|").filter(Boolean) : [];

--- a/app/frontend/utils/bubble-chart-permalink.ts
+++ b/app/frontend/utils/bubble-chart-permalink.ts
@@ -1,0 +1,167 @@
+import type { XAxisKey, YAxisKey } from "../types/bubble-chart.type";
+
+export interface ChartUiState {
+  xAxisKey: XAxisKey;
+  xAxisMode: "ranked" | "scaled";
+  yAxisKey: YAxisKey;
+  yAxisScaleType: "linear" | "log";
+  yAxisMin: string;
+  yAxisMax: string;
+  filterMoveRestriction: boolean;
+  filterEditRestriction: boolean;
+  centralityMin: number;
+  centralityMax: number;
+  includeNoCentrality: boolean;
+  searchTerm: string;
+  showLabels: boolean;
+  selectedGrades: Record<string, boolean>;
+}
+
+const CENTRALITY_MIN = 1;
+const CENTRALITY_MAX = 10;
+
+export const GRADE_KEYS = [
+  "FA",
+  "FL",
+  "A",
+  "GA",
+  "B",
+  "C",
+  "Start",
+  "Stub",
+  "List",
+  "Unassessed",
+];
+
+const X_AXIS_KEYS: XAxisKey[] = [
+  "title",
+  "publication_date",
+  "linguistic_versions_count",
+  "article_size",
+  "lead_section_size",
+  "talk_size",
+  "warning_tags_count",
+  "images_count",
+];
+const Y_AXIS_KEYS: YAxisKey[] = [
+  "average_daily_views",
+  "number_of_editors",
+  "incoming_links_count",
+];
+
+export const DEFAULT_CHART_UI_STATE: ChartUiState = {
+  xAxisKey: "title",
+  xAxisMode: "ranked",
+  yAxisKey: "average_daily_views",
+  yAxisScaleType: "linear",
+  yAxisMin: "",
+  yAxisMax: "",
+  filterMoveRestriction: false,
+  filterEditRestriction: false,
+  centralityMin: CENTRALITY_MIN,
+  centralityMax: CENTRALITY_MAX,
+  includeNoCentrality: true,
+  searchTerm: "",
+  showLabels: false,
+  selectedGrades: Object.fromEntries(GRADE_KEYS.map((g) => [g, true])),
+};
+
+function allGradesOn(selected: Record<string, boolean>): boolean {
+  return GRADE_KEYS.every((g) => selected[g] !== false);
+}
+
+export function encodeChartState(state: ChartUiState): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  if (state.xAxisKey !== "title") params.x = state.xAxisKey;
+  if (state.xAxisMode !== "ranked") params.xm = state.xAxisMode;
+  if (state.yAxisKey !== "average_daily_views") params.y = state.yAxisKey;
+  if (state.yAxisScaleType !== "linear") params.ys = state.yAxisScaleType;
+  if (state.yAxisMin.trim() !== "") params.ymin = state.yAxisMin.trim();
+  if (state.yAxisMax.trim() !== "") params.ymax = state.yAxisMax.trim();
+  if (state.filterMoveRestriction) params.mv = "1";
+  if (state.filterEditRestriction) params.ed = "1";
+  if (state.centralityMin !== CENTRALITY_MIN)
+    params.cmin = String(state.centralityMin);
+  if (state.centralityMax !== CENTRALITY_MAX)
+    params.cmax = String(state.centralityMax);
+  if (!state.includeNoCentrality) params.cna = "0";
+  if (state.searchTerm.trim() !== "") params.q = state.searchTerm.trim();
+  if (state.showLabels) params.lbl = "1";
+
+  if (!allGradesOn(state.selectedGrades)) {
+    const off = GRADE_KEYS.filter((g) => state.selectedGrades[g] === false);
+    if (off.length) params.off = off.join(",");
+  }
+
+  return params;
+}
+
+function clampCentrality(value: number): number {
+  if (!Number.isFinite(value)) return CENTRALITY_MIN;
+  return Math.min(CENTRALITY_MAX, Math.max(CENTRALITY_MIN, Math.round(value)));
+}
+
+// Decode URL params back into a full, validated state. Unknown / malformed
+// values silently fall back to their defaults.
+export function decodeChartState(params: URLSearchParams): ChartUiState {
+  const state: ChartUiState = {
+    ...DEFAULT_CHART_UI_STATE,
+    selectedGrades: { ...DEFAULT_CHART_UI_STATE.selectedGrades },
+  };
+
+  const x = params.get("x");
+  if (x && (X_AXIS_KEYS as string[]).includes(x))
+    state.xAxisKey = x as XAxisKey;
+
+  const xm = params.get("xm");
+  if (xm === "scaled" || xm === "ranked") state.xAxisMode = xm;
+  if (state.xAxisKey === "title") state.xAxisMode = "ranked";
+
+  const y = params.get("y");
+  if (y && (Y_AXIS_KEYS as string[]).includes(y))
+    state.yAxisKey = y as YAxisKey;
+
+  const ys = params.get("ys");
+  if (ys === "log" || ys === "linear") state.yAxisScaleType = ys;
+
+  const ymin = params.get("ymin");
+  if (ymin !== null && ymin.trim() !== "" && Number.isFinite(Number(ymin))) {
+    state.yAxisMin = ymin.trim();
+  }
+  const ymax = params.get("ymax");
+  if (ymax !== null && ymax.trim() !== "" && Number.isFinite(Number(ymax))) {
+    state.yAxisMax = ymax.trim();
+  }
+
+  state.filterMoveRestriction = params.get("mv") === "1";
+  state.filterEditRestriction = params.get("ed") === "1";
+
+  const cmin = params.get("cmin");
+  const cmax = params.get("cmax");
+  if (cmin !== null) state.centralityMin = clampCentrality(Number(cmin));
+  if (cmax !== null) state.centralityMax = clampCentrality(Number(cmax));
+  if (state.centralityMin > state.centralityMax) {
+    [state.centralityMin, state.centralityMax] = [
+      state.centralityMax,
+      state.centralityMin,
+    ];
+  }
+
+  state.includeNoCentrality = params.get("cna") !== "0";
+
+  const q = params.get("q");
+  if (q) state.searchTerm = q;
+
+  state.showLabels = params.get("lbl") === "1";
+
+  const off = params.get("off");
+  if (off) {
+    const offSet = new Set(off.split(","));
+    for (const g of GRADE_KEYS) {
+      if (offSet.has(g)) state.selectedGrades[g] = false;
+    }
+  }
+
+  return state;
+}

--- a/app/frontend/utils/bubble-chart-utils.tsx
+++ b/app/frontend/utils/bubble-chart-utils.tsx
@@ -147,6 +147,81 @@ function convertAnalyticsToCSV(
   return csvContent;
 }
 
+const ANALYTICS_EXPORT_HEADERS = [
+  "Article",
+  "Creation Date",
+  "Average Daily Views",
+  "Average Daily Views (prev year)",
+  "Article Size",
+  "Article Size (prev year)",
+  "Lead Section Size",
+  "Talk Size",
+  "Talk Size (prev year)",
+  "Number of Editors",
+  "Incoming Links",
+  "Centrality",
+  "Linguistic Versions",
+  "Warning Tags",
+  "Images",
+  "Assessment Grade",
+  "Protections",
+];
+
+// Escape characters that would break out of a wikitable cell ("|" / "||")
+// and flatten any stray newlines.
+function escapeWikitextCell(value: string): string {
+  return value.replace(/\|/g, "&#124;").replace(/[\r\n]+/g, " ");
+}
+
+function convertAnalyticsToWikitext(
+  rows: Array<{
+    article: string;
+    average_daily_views: number;
+    prev_average_daily_views: number | null;
+    article_size: number;
+    prev_article_size: number | null;
+    lead_section_size: number;
+    talk_size: number;
+    prev_talk_size: number | null;
+    number_of_editors: number;
+    incoming_links_count: number;
+    centrality: number | null;
+    linguistic_versions_count: number;
+    warning_tags_count: number;
+    images_count: number;
+    assessment_grade: string | null;
+    publication_date: string | null;
+    protection_summary?: string;
+  }>,
+): string {
+  let wikitext = '{| class="wikitable sortable"\n';
+  wikitext += `! ${ANALYTICS_EXPORT_HEADERS.join(" !! ")}\n`;
+  rows.forEach((row) => {
+    const cells = [
+      `[[${escapeWikitextCell(row.article)}]]`,
+      row.publication_date ?? "",
+      row.average_daily_views,
+      row.prev_average_daily_views ?? "",
+      row.article_size,
+      row.prev_article_size ?? "",
+      row.lead_section_size,
+      row.talk_size,
+      row.prev_talk_size ?? "",
+      row.number_of_editors,
+      row.incoming_links_count,
+      row.centrality ?? "",
+      row.linguistic_versions_count,
+      row.warning_tags_count,
+      row.images_count,
+      row.assessment_grade ?? "",
+      escapeWikitextCell(row.protection_summary ?? ""),
+    ];
+    wikitext += `|-\n| ${cells.join(" || ")}\n`;
+  });
+  wikitext += "|}\n";
+  return wikitext;
+}
+
 function makeSqrtAreaScale(
   values: number[],
   [rangeMin, rangeMax]: [number, number],
@@ -200,6 +275,7 @@ export {
   formatProtectionSummary,
   xAxisTitleForKey,
   convertAnalyticsToCSV,
+  convertAnalyticsToWikitext,
   getAssessmentColor,
   makeSqrtAreaScale,
 };

--- a/app/frontend/utils/chart-image-export.ts
+++ b/app/frontend/utils/chart-image-export.ts
@@ -1,0 +1,167 @@
+import { downloadBlob } from "./search-utils";
+
+interface VegaViewLike {
+  toCanvas(scale?: number): Promise<HTMLCanvasElement>;
+}
+
+interface ExportChartImageOptions {
+  view: VegaViewLike;
+  logoSrc: string;
+  title: string;
+  dateRangeLabel?: string | null;
+  generatedLabel: string;
+  permalink: string;
+  filename: string;
+}
+
+const SCALE = 2;
+const PRIMARY = "#1976d2";
+const TEXT_STRONG = "#424242";
+const TEXT_MUTED = "#757575";
+const BG = "#ffffff";
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+function fitText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  const ellipsis = "…";
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (ctx.measureText(text.slice(0, mid) + ellipsis).width <= maxWidth) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return text.slice(0, lo) + ellipsis;
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("Failed to render chart image"));
+    }, "image/png");
+  });
+}
+
+export async function exportChartImage(
+  opts: ExportChartImageOptions,
+): Promise<void> {
+  const chartCanvas = await opts.view.toCanvas(SCALE);
+
+  let logo: HTMLImageElement | null = null;
+  try {
+    logo = await loadImage(opts.logoSrc);
+  } catch {
+    logo = null;
+  }
+
+  const pad = 24 * SCALE;
+  const gap = 16 * SCALE;
+  const logoHeight = logo ? 34 * SCALE : 0;
+  const logoWidth = logo ? (logo.width / logo.height) * logoHeight : 0;
+
+  const titleFont = `600 ${18 * SCALE}px sans-serif`;
+  const subtitleFont = `${13 * SCALE}px sans-serif`;
+  const footerFont = `${12 * SCALE}px sans-serif`;
+  const linkFont = `${11 * SCALE}px sans-serif`;
+
+  const titleLineH = 22 * SCALE;
+  const subtitleLineH = 17 * SCALE;
+  const titleBlockH = opts.dateRangeLabel
+    ? titleLineH + subtitleLineH
+    : titleLineH;
+
+  const headerContentH = Math.max(logoHeight, titleBlockH);
+  const headerH = pad + headerContentH + pad;
+
+  const footerLineH = 16 * SCALE;
+  const footerH = pad / 2 + footerLineH * 2 + pad / 2;
+
+  const width = chartCanvas.width;
+  const height = headerH + chartCanvas.height + footerH;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context unavailable");
+
+  ctx.fillStyle = BG;
+  ctx.fillRect(0, 0, width, height);
+
+  let textLeft = pad;
+  if (logo) {
+    const logoY = pad + (headerContentH - logoHeight) / 2;
+    ctx.drawImage(logo, pad, logoY, logoWidth, logoHeight);
+    textLeft = pad + logoWidth + gap;
+  }
+
+  const textMaxWidth = width - textLeft - pad;
+  const titleTop = pad + (headerContentH - titleBlockH) / 2;
+
+  ctx.textBaseline = "top";
+  ctx.fillStyle = TEXT_STRONG;
+  ctx.font = titleFont;
+  ctx.fillText(fitText(ctx, opts.title, textMaxWidth), textLeft, titleTop);
+
+  if (opts.dateRangeLabel) {
+    ctx.fillStyle = TEXT_MUTED;
+    ctx.font = subtitleFont;
+    ctx.fillText(
+      fitText(ctx, opts.dateRangeLabel, textMaxWidth),
+      textLeft,
+      titleTop + titleLineH,
+    );
+  }
+
+  ctx.drawImage(chartCanvas, 0, headerH);
+
+  const footerTop = headerH + chartCanvas.height;
+  ctx.strokeStyle = "#e0e0e0";
+  ctx.lineWidth = 1 * SCALE;
+  ctx.beginPath();
+  ctx.moveTo(pad, footerTop + 0.5 * SCALE);
+  ctx.lineTo(width - pad, footerTop + 0.5 * SCALE);
+  ctx.stroke();
+
+  const footerTextTop = footerTop + pad / 2;
+  ctx.textBaseline = "top";
+  ctx.font = footerFont;
+  ctx.fillStyle = TEXT_MUTED;
+  ctx.textAlign = "left";
+  ctx.fillText(
+    "Visualizing Impact · Wiki Education Foundation",
+    pad,
+    footerTextTop,
+  );
+
+  ctx.textAlign = "right";
+  ctx.fillText(opts.generatedLabel, width - pad, footerTextTop);
+
+  ctx.textAlign = "left";
+  ctx.font = linkFont;
+  ctx.fillStyle = PRIMARY;
+  ctx.fillText(
+    fitText(ctx, opts.permalink, width - pad * 2),
+    pad,
+    footerTextTop + footerLineH,
+  );
+
+  const blob = await canvasToBlob(canvas);
+  downloadBlob(blob, `${opts.filename}.png`);
+}

--- a/app/frontend/utils/search-utils.ts
+++ b/app/frontend/utils/search-utils.ts
@@ -118,6 +118,15 @@ function downloadAsTXT(txtContent: string, fileName = "data"): void {
   link.click();
 }
 
+function downloadBlob(blob: Blob, fileName = "download"): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.setAttribute("href", url);
+  link.setAttribute("download", fileName);
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
 const convertInitialResponseToTree = (
   response: MediaWikiResponse,
   existingIDs: INode<IFlatMetadata>[],
@@ -311,6 +320,7 @@ export {
   convertArticlesToCSV,
   downloadAsCSV,
   downloadAsTXT,
+  downloadBlob,
   convertInitialResponseToTree,
   convertResponseToTree,
   removeCategoryPrefix,

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -177,6 +177,11 @@ class Topic < ApplicationRecord
       ]
     )
 
+    # Per-article tag (Classification) names for this topic, keyed by title.
+    # Fetched separately rather than joined into the pluck above, which would
+    # duplicate analytics rows for articles carrying more than one tag.
+    names_by_title = article_classification_names_by_title
+
     topic_article_analytics
       .joins(:article)
       .joins(centrality_join)
@@ -185,8 +190,24 @@ class Topic < ApplicationRecord
         [title,
          { average_daily_views:, prev_average_daily_views:, article_size:, prev_article_size:, talk_size:, prev_talk_size:,
           lead_section_size:, assessment_grade:, publication_date:, linguistic_versions_count:, warning_tags_count:,
-          images_count:, number_of_editors:, article_protections:, incoming_links_count:, centrality: }]
+          images_count:, number_of_editors:, article_protections:, incoming_links_count:, centrality:,
+          classifications: names_by_title[title] || [] }]
       end
+  end
+
+  # Maps article title => sorted, unique list of this topic's Classification
+  # names the article belongs to. Scoped to the active bag so it lines up with
+  # the articles in article_analytics_data.
+  def article_classification_names_by_title
+    ArticleClassification
+      .joins(:article, :classification)
+      .where(classification_id: classification_ids,
+             articles: { id: active_article_bag&.article_ids })
+      .pluck('articles.title', 'classifications.name')
+      .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(title, name), acc|
+        acc[title] << name
+      end
+      .transform_values { |names| names.uniq.sort }
   end
 
   def article_analytics_exist?

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -199,7 +199,7 @@ class Topic < ApplicationRecord
   # names the article belongs to. Scoped to the active bag so it lines up with
   # the articles in article_analytics_data.
   def article_classification_names_by_title
-    ArticleClassification
+    names_by_title = ArticleClassification
       .joins(:article, :classification)
       .where(classification_id: classification_ids,
              articles: { id: active_article_bag&.article_ids })
@@ -207,7 +207,7 @@ class Topic < ApplicationRecord
       .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(title, name), acc|
         acc[title] << name
       end
-      .transform_values { |names| names.uniq.sort }
+    names_by_title.transform_values { |names| names.uniq.sort }
   end
 
   def article_analytics_exist?

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -596,6 +596,40 @@ RSpec.describe Topic do
       expect(data.keys).to contain_exactly('In')
       expect(data['Out']).to be_nil
     end
+
+    context 'with classifications' do
+      let(:biography) do
+        Classification.create!(name: 'biography', prerequisites: [], properties: [],
+                               source: Classification::SOURCE_TB_PAYLOAD)
+      end
+      let(:movement) do
+        Classification.create!(name: 'movement', prerequisites: [], properties: [],
+                               source: Classification::SOURCE_TB_PAYLOAD)
+      end
+
+      before do
+        topic.classifications << biography
+        topic.classifications << movement
+        ArticleClassification.create!(classification: biography, article: article_in_bag, properties: [])
+        ArticleClassification.create!(classification: movement, article: article_in_bag, properties: [])
+      end
+
+      it 'includes the sorted, unique tag names the article belongs to' do
+        expect(topic.article_analytics_data['In'][:classifications]).to eq(%w[biography movement])
+      end
+
+      it 'returns an empty array for articles with no tags' do
+        ArticleClassification.where(article: article_in_bag).destroy_all
+        expect(topic.article_analytics_data['In'][:classifications]).to eq([])
+      end
+
+      it 'ignores classifications that do not belong to the topic' do
+        other = Classification.create!(name: 'unrelated', prerequisites: [], properties: [],
+                                       source: Classification::SOURCE_TB_PAYLOAD)
+        ArticleClassification.create!(classification: other, article: article_in_bag, properties: [])
+        expect(topic.article_analytics_data['In'][:classifications]).to eq(%w[biography movement])
+      end
+    end
   end
 
   describe '#total_average_daily_visits' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -610,8 +610,10 @@ RSpec.describe Topic do
       before do
         topic.classifications << biography
         topic.classifications << movement
-        ArticleClassification.create!(classification: biography, article: article_in_bag, properties: [])
-        ArticleClassification.create!(classification: movement, article: article_in_bag, properties: [])
+        ArticleClassification.create!(classification: biography, article: article_in_bag,
+                                      properties: [])
+        ArticleClassification.create!(classification: movement, article: article_in_bag,
+                                      properties: [])
       end
 
       it 'includes the sorted, unique tag names the article belongs to' do
@@ -626,7 +628,8 @@ RSpec.describe Topic do
       it 'ignores classifications that do not belong to the topic' do
         other = Classification.create!(name: 'unrelated', prerequisites: [], properties: [],
                                        source: Classification::SOURCE_TB_PAYLOAD)
-        ArticleClassification.create!(classification: other, article: article_in_bag, properties: [])
+        ArticleClassification.create!(classification: other, article: article_in_bag,
+                                      properties: [])
         expect(topic.article_analytics_data['In'][:classifications]).to eq(%w[biography movement])
       end
     end


### PR DESCRIPTION
## Changes

**New features**
- Added the ability to permalink the chart state
  - All chart controls (axes, scale type, y-axis range, quality/protection/centrality filters, tags, search term, labels, and excluded articles) are encoded into the URL via a new "Copy link" button
  - Opening a shared link restores the exact same chart view
- Added the ability to export the chart as an image
  - New "Save image" button downloads the current chart as a PNG, with the topic title, focus period date range, generated-on date, logo, and a permalink back to the view
- Added the ability to export topic articles as wikitext
  - New wikitext export button alongside the existing CSV export, respecting the current filters
- Added the ability to manually exclude articles from the chart
  - Individual articles can be trimmed from the filtered-articles sidebar, with a clear-all option
  - Excluded articles are also removed from the auto y-axis domain so the remaining bubbles rescale, and the exclusions persist in the permalink
- Added the ability to filter by tags
  - New tag filter section lets you toggle individual article tags on/off, with select/deselect all
  - Article tag names are now surfaced per-article in the topic analytics data

**Refactoring**
- Rubocop fixes

## Video
**Permalink and image saving demo**

https://github.com/user-attachments/assets/31a59ad5-1c98-434b-a89a-fa407d96976b

**Article exclusion and tag filtering demo**

https://github.com/user-attachments/assets/57e0aeb6-f0b0-4e15-b853-072adcce6a0f

