### PR TITLE
New filter layout and language ordering + code refactoring

### DIFF
--- a/app/frontend/components/advanced-filter-panel.component.tsx
+++ b/app/frontend/components/advanced-filter-panel.component.tsx
@@ -1,0 +1,348 @@
+import React from "react";
+import { BsEye, BsEyeSlash } from "react-icons/bs";
+import {
+  CENTRALITY_MIN,
+  CENTRALITY_MAX,
+} from "../utils/bubble-chart-permalink";
+
+const gradeGroups = [
+  { id: "fa", label: "Featured", grades: ["FA", "FL"], dot: "#9CBDFF" },
+  { id: "ga", label: "GA", grades: ["GA"], dot: "#66FF66" },
+  { id: "aclass", label: "A-Class", grades: ["A"], dot: "#66FFFF" },
+  { id: "bclass", label: "B-Class", grades: ["B"], dot: "#B2FF66" },
+  { id: "cclass", label: "C-Class", grades: ["C"], dot: "#FFFF66" },
+  { id: "start", label: "Start", grades: ["Start"], dot: "#FFAA66" },
+  { id: "stub", label: "Stub", grades: ["Stub"], dot: "#FFA4A4" },
+  { id: "list", label: "List", grades: ["List"], dot: "#C7B1FF" },
+  {
+    id: "unassessed",
+    label: "Unassessed",
+    grades: ["Unassessed"],
+    dot: "#9E9E9E",
+  },
+];
+
+function QualityFilterButtons({
+  onToggle,
+  selected,
+  onReset,
+}: {
+  onToggle: (grades: string[], on: boolean) => void;
+  selected: Record<string, boolean>;
+  onReset: () => void;
+}) {
+  return (
+    <div className="QualityAssessment">
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by quality assessment*</div>
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset all
+        </button>
+      </div>
+      <div className="FilterList">
+        {gradeGroups.map((g) => {
+          const isOn = g.grades.every((x) => selected[x] !== false);
+          return (
+            <button
+              key={g.id}
+              type="button"
+              className={`FilterRow ${isOn ? "is-on" : "is-off"}`}
+              data-group={g.id}
+              aria-pressed={isOn}
+              onClick={() => onToggle(g.grades, !isOn)}
+            >
+              {isOn ? (
+                <BsEye className="EyeIcon" />
+              ) : (
+                <BsEyeSlash className="EyeIcon" />
+              )}
+              <span className="Dot" style={{ backgroundColor: g.dot }} />
+              <span className="Label">{g.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TagFilterButtons({
+  tags,
+  deselected,
+  includeUntagged,
+  onToggle,
+  onIncludeUntaggedChange,
+  onReset,
+}: {
+  tags: string[];
+  deselected: Set<string>;
+  includeUntagged: boolean;
+  onToggle: (tag: string, on: boolean) => void;
+  onIncludeUntaggedChange: (checked: boolean) => void;
+  onReset: () => void;
+}) {
+  return (
+    <div className="TagFilter">
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by tags</div>
+        <label className="Checkbox">
+          <input
+            type="checkbox"
+            checked={includeUntagged}
+            onChange={(e) => onIncludeUntaggedChange(e.target.checked)}
+            aria-label="Include untagged articles"
+          />
+          <span>include untagged</span>
+        </label>
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset all
+        </button>
+      </div>
+      <div className="FilterList">
+        {tags.map((tag) => {
+          const isOn = !deselected.has(tag);
+          return (
+            <button
+              key={tag}
+              type="button"
+              className={`FilterRow ${isOn ? "is-on" : "is-off"}`}
+              aria-pressed={isOn}
+              onClick={() => onToggle(tag, !isOn)}
+            >
+              {isOn ? (
+                <BsEye className="EyeIcon" />
+              ) : (
+                <BsEyeSlash className="EyeIcon" />
+              )}
+              <span className="Label">{tag}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ProtectionFilterCheckboxes({
+  moveChecked,
+  editChecked,
+  onMoveChange,
+  onEditChange,
+  onReset,
+}: {
+  moveChecked: boolean;
+  editChecked: boolean;
+  onMoveChange: (checked: boolean) => void;
+  onEditChange: (checked: boolean) => void;
+  onReset: () => void;
+}) {
+  const rows = [
+    { label: "Move restriction", checked: moveChecked, onChange: onMoveChange },
+    { label: "Edit restriction", checked: editChecked, onChange: onEditChange },
+  ];
+  return (
+    <div className="ProtectionFilter">
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by article protection</div>
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset
+        </button>
+      </div>
+      <div className="FilterList">
+        {rows.map((row) => (
+          <button
+            key={row.label}
+            type="button"
+            className={`FilterRow ${row.checked ? "is-on" : "is-off"}`}
+            aria-pressed={row.checked}
+            onClick={() => row.onChange(!row.checked)}
+          >
+            {row.checked ? (
+              <BsEye className="EyeIcon" />
+            ) : (
+              <BsEyeSlash className="EyeIcon" />
+            )}
+            <span className="Label">{row.label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CentralityFilter({
+  min,
+  max,
+  includeUnassessed,
+  onMinChange,
+  onMaxChange,
+  onIncludeUnassessedChange,
+  onReset,
+}: {
+  min: number;
+  max: number;
+  includeUnassessed: boolean;
+  onMinChange: (value: number) => void;
+  onMaxChange: (value: number) => void;
+  onIncludeUnassessedChange: (checked: boolean) => void;
+  onReset: () => void;
+}) {
+  const minPercent =
+    ((min - CENTRALITY_MIN) / (CENTRALITY_MAX - CENTRALITY_MIN)) * 100;
+  const maxPercent =
+    ((max - CENTRALITY_MIN) / (CENTRALITY_MAX - CENTRALITY_MIN)) * 100;
+
+  return (
+    <div className="CentralityFilter">
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by centrality</div>
+        <label className="Checkbox">
+          <input
+            type="checkbox"
+            checked={includeUnassessed}
+            onChange={(e) => onIncludeUnassessedChange(e.target.checked)}
+            aria-label="Include articles with no centrality"
+          />
+          <span>include articles without centrality</span>
+        </label>
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset
+        </button>
+      </div>
+      <div className="Value">
+        {min}-{max}
+      </div>
+      <div className="Slider">
+        <div className="Track" />
+        <div
+          className="Range"
+          style={{ left: `${minPercent}%`, right: `${100 - maxPercent}%` }}
+        />
+        <input
+          type="range"
+          min={CENTRALITY_MIN}
+          max={CENTRALITY_MAX}
+          step={1}
+          value={min}
+          onChange={(e) => onMinChange(Number(e.target.value))}
+          aria-label="Minimum centrality"
+          className="Input Input--min"
+        />
+        <input
+          type="range"
+          min={CENTRALITY_MIN}
+          max={CENTRALITY_MAX}
+          step={1}
+          value={max}
+          onChange={(e) => onMaxChange(Number(e.target.value))}
+          aria-label="Maximum centrality"
+          className="Input Input--max"
+        />
+      </div>
+      <div className="Bounds">
+        <span>{CENTRALITY_MIN} (min)</span>
+        <span>{CENTRALITY_MAX} (max)</span>
+      </div>
+    </div>
+  );
+}
+
+export interface AdvancedFilterPanelProps {
+  tags: string[];
+  deselectedTags: Set<string>;
+  includeUntagged: boolean;
+  onToggleTag: (tag: string, on: boolean) => void;
+  onIncludeUntaggedChange: (checked: boolean) => void;
+  onResetTags: () => void;
+
+  centralityMin: number;
+  centralityMax: number;
+  includeNoCentrality: boolean;
+  onCentralityMinChange: (value: number) => void;
+  onCentralityMaxChange: (value: number) => void;
+  onIncludeNoCentralityChange: (checked: boolean) => void;
+  onResetCentrality: () => void;
+
+  selectedGrades: Record<string, boolean>;
+  onToggleGrades: (grades: string[], on: boolean) => void;
+  onResetGrades: () => void;
+
+  moveRestriction: boolean;
+  editRestriction: boolean;
+  onMoveRestrictionChange: (checked: boolean) => void;
+  onEditRestrictionChange: (checked: boolean) => void;
+  onResetProtection: () => void;
+}
+
+const AdvancedFilterPanel: React.FC<AdvancedFilterPanelProps> = ({
+  tags,
+  deselectedTags,
+  includeUntagged,
+  onToggleTag,
+  onIncludeUntaggedChange,
+  onResetTags,
+  centralityMin,
+  centralityMax,
+  includeNoCentrality,
+  onCentralityMinChange,
+  onCentralityMaxChange,
+  onIncludeNoCentralityChange,
+  onResetCentrality,
+  selectedGrades,
+  onToggleGrades,
+  onResetGrades,
+  moveRestriction,
+  editRestriction,
+  onMoveRestrictionChange,
+  onEditRestrictionChange,
+  onResetProtection,
+}) => {
+  return (
+    <div className={`AdvancedPanel ${tags.length ? "has-tags" : ""}`}>
+      {tags.length > 0 && (
+        <div className="FilterBox FilterBox--tags">
+          <TagFilterButtons
+            tags={tags}
+            deselected={deselectedTags}
+            includeUntagged={includeUntagged}
+            onToggle={onToggleTag}
+            onIncludeUntaggedChange={onIncludeUntaggedChange}
+            onReset={onResetTags}
+          />
+        </div>
+      )}
+
+      <div className="FilterBox">
+        <CentralityFilter
+          min={centralityMin}
+          max={centralityMax}
+          includeUnassessed={includeNoCentrality}
+          onMinChange={onCentralityMinChange}
+          onMaxChange={onCentralityMaxChange}
+          onIncludeUnassessedChange={onIncludeNoCentralityChange}
+          onReset={onResetCentrality}
+        />
+      </div>
+
+      <div className="FilterBox FilterBox--quality">
+        <QualityFilterButtons
+          onToggle={onToggleGrades}
+          selected={selectedGrades}
+          onReset={onResetGrades}
+        />
+      </div>
+
+      <div className="FilterBox">
+        <ProtectionFilterCheckboxes
+          moveChecked={moveRestriction}
+          editChecked={editRestriction}
+          onMoveChange={onMoveRestrictionChange}
+          onEditChange={onEditRestrictionChange}
+          onReset={onResetProtection}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedFilterPanel;

--- a/app/frontend/components/article-language-comparison-modal.component.tsx
+++ b/app/frontend/components/article-language-comparison-modal.component.tsx
@@ -148,10 +148,7 @@ function ArticleLanguageComparisonModal({
                         setDragOverIndex(null);
                       }}
                     >
-                      <th
-                        scope="row"
-                        className={`LangHeader${!entry ? " LangHeader--missing" : ""}`}
-                      >
+                      <th scope="row" className="LangHeader">
                         <div className="LangHeader-inner">
                           <MdDragIndicator
                             className="DragHandle"

--- a/app/frontend/components/article-language-comparison-modal.component.tsx
+++ b/app/frontend/components/article-language-comparison-modal.component.tsx
@@ -1,12 +1,14 @@
-import React from "react";
+import React, { useState } from "react";
 import { FiEdit2, FiExternalLink } from "react-icons/fi";
 import { IoClose, IoCloseCircle } from "react-icons/io5";
+import { MdDragIndicator } from "react-icons/md";
 import { useQuery } from "@tanstack/react-query";
 import Spinner from "./spinner.component";
 import TopicService from "../services/topic.service";
 import type { LangComparisonData } from "../services/topic.service";
 import { LANGUAGE_LABELS, getTranslateUrl } from "../utils/language-links";
 import type { TargetLanguage } from "../utils/language-links";
+import { reorder, useLanguageOrder } from "../utils/language-order";
 import { getWikiUrl } from "../utils/search-utils";
 
 type Wiki = {
@@ -43,6 +45,10 @@ function ArticleLanguageComparisonModal({
   onClose,
 }: ArticleLanguageComparisonModalProps) {
   const sourceLang = wiki?.language ?? "en";
+
+  const [orderedLanguages, setOrderedLanguages] = useLanguageOrder(languages);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const { data, status, error } = useQuery({
     queryKey: ["langComparison", topicId, articleTitle],
@@ -105,102 +111,120 @@ function ArticleLanguageComparisonModal({
             <table className="Table">
               <thead>
                 <tr>
-                  <th className="MetricHeader" />
-                  {languages.map((lang) => {
-                    const entry = data[lang];
-                    return (
-                      <th
-                        key={lang}
-                        className={`LangHeader${!entry ? " LangHeader--missing" : ""}`}
-                      >
-                        <span>{LANGUAGE_LABELS[lang] ?? lang} version</span>
-                        {entry && (
-                          <a
-                            href={getWikiUrl(entry.title, { language: lang })}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="Link"
-                            aria-label={`Open ${LANGUAGE_LABELS[lang]} version`}
-                          >
-                            <FiExternalLink size={14} />
-                          </a>
-                        )}
-                      </th>
-                    );
-                  })}
+                  <th className="CornerHeader" />
+                  {METRIC_ROWS.map((metric) => (
+                    <th key={metric.key} className="MetricHeader">
+                      {metric.label}
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody>
-                {METRIC_ROWS.map((metric) => (
-                  <tr key={metric.key}>
-                    <td className="MetricLabel">
-                      {metric.label}
-                    </td>
-                    {languages.map((lang) => {
-                      const entry = data[lang];
-                      if (!entry) {
+                {orderedLanguages.map((lang, i) => {
+                  const entry = data[lang];
+                  return (
+                    <tr
+                      key={lang}
+                      className={`LangRow${
+                        dragOverIndex === i ? " LangRow--dragover" : ""
+                      }${dragIndex === i ? " LangRow--dragging" : ""}`}
+                      draggable
+                      onDragStart={() => setDragIndex(i)}
+                      onDragOver={(e) => {
+                        e.preventDefault();
+                        if (dragOverIndex !== i) setDragOverIndex(i);
+                      }}
+                      onDrop={() => {
+                        if (dragIndex !== null && dragIndex !== i) {
+                          setOrderedLanguages(
+                            reorder(orderedLanguages, dragIndex, i),
+                          );
+                        }
+                        setDragIndex(null);
+                        setDragOverIndex(null);
+                      }}
+                      onDragEnd={() => {
+                        setDragIndex(null);
+                        setDragOverIndex(null);
+                      }}
+                    >
+                      <th
+                        scope="row"
+                        className={`LangHeader${!entry ? " LangHeader--missing" : ""}`}
+                      >
+                        <div className="LangHeader-inner">
+                          <MdDragIndicator
+                            className="DragHandle"
+                            size={22}
+                            aria-hidden="true"
+                          />
+                          <span className="LangName">
+                            {LANGUAGE_LABELS[lang] ?? lang} version
+                          </span>
+                          {entry ? (
+                            <a
+                              href={getWikiUrl(entry.title, { language: lang })}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="Link"
+                              aria-label={`Open ${LANGUAGE_LABELS[lang]} version`}
+                            >
+                              <FiExternalLink size={14} />
+                            </a>
+                          ) : (
+                            <a
+                              className="TranslateLink"
+                              href={getTranslateUrl(
+                                articleTitle,
+                                sourceLang,
+                                lang,
+                              )}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <FiEdit2 size={14} />
+                              <span>Translate article</span>
+                            </a>
+                          )}
+                        </div>
+                      </th>
+                      {METRIC_ROWS.map((metric) => {
+                        if (!entry) {
+                          return (
+                            <td
+                              key={metric.key}
+                              className="Cell Cell--missing"
+                            >
+                              <span className="MissingIcon">
+                                <IoCloseCircle size={22} />
+                              </span>
+                            </td>
+                          );
+                        }
+
+                        const value = entry[metric.key];
+                        const max = maxValues[metric.key] || 1;
+                        const barWidth = max > 0 ? (value / max) * 100 : 0;
+
                         return (
-                          <td
-                            key={lang}
-                            className="Cell Cell--missing"
-                          >
-                            <span className="MissingIcon">
-                              <IoCloseCircle size={22} />
-                            </span>
+                          <td key={metric.key} className="Cell">
+                            <div className="Inner">
+                              <span className="Value">
+                                {value.toLocaleString()}
+                              </span>
+                              <div className="Track">
+                                <div
+                                  className="Bar"
+                                  style={{ width: `${barWidth}%` }}
+                                />
+                              </div>
+                            </div>
                           </td>
                         );
-                      }
-
-                      const value = entry[metric.key];
-                      const max = maxValues[metric.key] || 1;
-                      const barWidth = max > 0 ? (value / max) * 100 : 0;
-
-                      return (
-                        <td key={lang} className="Cell">
-                          <div className="Inner">
-                            <span className="Value">
-                              {value.toLocaleString()}
-                            </span>
-                            <div className="Track">
-                              <div
-                                className="Bar"
-                                style={{ width: `${barWidth}%` }}
-                              />
-                            </div>
-                          </div>
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))}
-
-                <tr>
-                  <td className="MetricLabel" />
-                  {languages.map((lang) => {
-                    const entry = data[lang];
-                    if (entry) {
-                      return (
-                        <td key={lang} className="Cell" />
-                      );
-                    }
-                    return (
-                      <td
-                        key={lang}
-                        className="Cell Cell--missing Cell--translate"
-                      >
-                        <a
-                          className="TranslateLink"
-                          href={getTranslateUrl(articleTitle, sourceLang, lang)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          <FiEdit2 size={14} />
-                          <span>Translate article</span>
-                        </a>
-                      </td>
-                    );
-                  })}
-                </tr>
+                      })}
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           )}

--- a/app/frontend/components/article-languages-grid.component.tsx
+++ b/app/frontend/components/article-languages-grid.component.tsx
@@ -3,9 +3,11 @@ import { useQueries } from "@tanstack/react-query";
 import { BsInfoCircle } from "react-icons/bs";
 import { FiEdit2 } from "react-icons/fi";
 import { IoCloseCircle } from "react-icons/io5";
+import { MdDragIndicator } from "react-icons/md";
 import Spinner from "./spinner.component";
 import usePagination from "../hooks/usePagination";
 import { LANGUAGE_LABELS, getTranslateUrl } from "../utils/language-links";
+import { reorder, useLanguageOrder } from "../utils/language-order";
 import { makeSqrtAreaScale } from "../utils/bubble-chart-utils";
 import BubbleCell from "./bubble-cell.component";
 import TopicService from "../services/topic.service";
@@ -192,6 +194,10 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
 
   const sourceLang = wiki?.language ?? "en";
 
+  const [orderedLanguages, setOrderedLanguages] = useLanguageOrder(languages);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
   const scaleSource = allArticles ?? articles;
 
   const radiusScales = useMemo<RadiusScales>(() => {
@@ -221,7 +227,11 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
     queries: currentPageData.map((row, i) => ({
       queryKey: ["langComparison", topicId, row.article],
       queryFn: ({ signal }) =>
-        TopicService.getArticleLanguageComparison(topicId!, row.article, signal),
+        TopicService.getArticleLanguageComparison(
+          topicId!,
+          row.article,
+          signal,
+        ),
       enabled: !!topicId && !loading && i <= unlockedIdx,
       staleTime: LANG_DATA_STALE_MS,
       gcTime: LANG_DATA_STALE_MS,
@@ -281,10 +291,7 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
         </div>
         {progress && progress.total > 0 && (
           <div className="Progress">
-            <div
-              className="Bar"
-              style={{ width: `${pct}%` }}
-            />
+            <div className="Bar" style={{ width: `${pct}%` }} />
           </div>
         )}
       </div>
@@ -297,9 +304,7 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
 
   if (articles.length === 0) {
     return (
-      <div className="Grid--empty">
-        No articles match the current filters.
-      </div>
+      <div className="Grid--empty">No articles match the current filters.</div>
     );
   }
 
@@ -316,9 +321,38 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
                 </span>
               </div>
             </th>
-            {languages.map((lang) => (
-              <th key={lang} className="HeaderLang">
-                {LANGUAGE_LABELS[lang] ?? lang} version
+            {orderedLanguages.map((lang, i) => (
+              <th
+                key={lang}
+                className={`HeaderLang${
+                  dragOverIndex === i ? " HeaderLang--dragover" : ""
+                }${dragIndex === i ? " HeaderLang--dragging" : ""}`}
+                draggable
+                onDragStart={() => setDragIndex(i)}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  if (dragOverIndex !== i) setDragOverIndex(i);
+                }}
+                onDrop={() => {
+                  if (dragIndex !== null && dragIndex !== i) {
+                    setOrderedLanguages(reorder(orderedLanguages, dragIndex, i));
+                  }
+                  setDragIndex(null);
+                  setDragOverIndex(null);
+                }}
+                onDragEnd={() => {
+                  setDragIndex(null);
+                  setDragOverIndex(null);
+                }}
+              >
+                <div className="HeaderLang-inner">
+                  <MdDragIndicator
+                    className="DragHandle"
+                    size={35}
+                    aria-hidden="true"
+                  />
+                  <span>{LANGUAGE_LABELS[lang] ?? lang} version</span>
+                </div>
               </th>
             ))}
           </tr>
@@ -344,7 +378,7 @@ const ArticleLanguagesGrid: React.FC<ArticleLanguagesGridProps> = ({
                 >
                   {row.article}
                 </td>
-                {languages.map((lang) => (
+                {orderedLanguages.map((lang) => (
                   <LanguageCell
                     key={lang}
                     articleTitle={row.article}

--- a/app/frontend/components/axis-controls.component.tsx
+++ b/app/frontend/components/axis-controls.component.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import { FaArrowRight, FaArrowUp } from "react-icons/fa6";
+import type { XAxisKey, YAxisKey } from "../types/bubble-chart.type";
+
+export interface AxisControlsProps {
+  idPrefix: string;
+  hideYAxis?: boolean;
+  yAxisKey: YAxisKey;
+  onYAxisKeyChange: (key: YAxisKey) => void;
+  yAxisScaleType: "linear" | "log";
+  onYAxisScaleTypeChange: (type: "linear" | "log") => void;
+  yAxisMinInput: string;
+  onYAxisMinInputChange: (value: string) => void;
+  yAxisMaxInput: string;
+  onYAxisMaxInputChange: (value: string) => void;
+  yAxisAutoDomain: { min: number | null; max: number | null };
+  xAxisKey: XAxisKey;
+  onXAxisKeyChange: (key: XAxisKey) => void;
+  xAxisMode: "ranked" | "scaled";
+  onXAxisModeChange: (mode: "ranked" | "scaled") => void;
+}
+
+const AxisControls: React.FC<AxisControlsProps> = ({
+  idPrefix,
+  hideYAxis = false,
+  yAxisKey,
+  onYAxisKeyChange,
+  yAxisScaleType,
+  onYAxisScaleTypeChange,
+  yAxisMinInput,
+  onYAxisMinInputChange,
+  yAxisMaxInput,
+  onYAxisMaxInputChange,
+  yAxisAutoDomain,
+  xAxisKey,
+  onXAxisKeyChange,
+  xAxisMode,
+  onXAxisModeChange,
+}) => {
+  const yAxisId = `${idPrefix}-y-axis`;
+  const xAxisId = `${idPrefix}-sort`;
+
+  return (
+    <div
+      className={`AxisControls ${hideYAxis ? "AxisControls--horizontalOnly" : ""}`}
+    >
+      {!hideYAxis && (
+      <>
+      <div className="FilterBox">
+        <div className="AxisControl">
+          <FaArrowUp size={30} className="AxisIcon" />
+          <div className="AxisFields">
+            <div className="AxisLabelRow">
+              <label htmlFor={yAxisId} className="BoxTitle">
+                Vertical axis
+              </label>
+              <div className="ScaleToggle">
+                <button
+                  type="button"
+                  className={`ScaleBtn ${yAxisScaleType === "linear" ? "is-active" : ""}`}
+                  onClick={() => onYAxisScaleTypeChange("linear")}
+                >
+                  Linear
+                </button>
+                <button
+                  type="button"
+                  className={`ScaleBtn ${yAxisScaleType === "log" ? "is-active" : ""}`}
+                  onClick={() => onYAxisScaleTypeChange("log")}
+                >
+                  Log
+                </button>
+              </div>
+            </div>
+            <select
+              id={yAxisId}
+              className="SortSelect"
+              value={yAxisKey}
+              onChange={(e) => onYAxisKeyChange(e.target.value as YAxisKey)}
+            >
+              <option value="average_daily_views">Avg daily views</option>
+              <option value="number_of_editors">Editors</option>
+              <option value="incoming_links_count">Incoming links</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div className="FilterBox">
+        <div className="BoxTitle">Y-axis range</div>
+        <div className="RangeRow">
+          <label className="RangeField">
+            <span className="RangeLabel">min</span>
+            <input
+              className="RangeInput"
+              type="number"
+              inputMode="numeric"
+              placeholder={
+                yAxisAutoDomain.min === null ? "" : String(yAxisAutoDomain.min)
+              }
+              value={yAxisMinInput}
+              onChange={(e) => onYAxisMinInputChange(e.target.value)}
+              aria-label="Y-axis minimum"
+            />
+          </label>
+          <label className="RangeField">
+            <span className="RangeLabel">max</span>
+            <input
+              className="RangeInput"
+              type="number"
+              inputMode="numeric"
+              placeholder={
+                yAxisAutoDomain.max === null ? "" : String(yAxisAutoDomain.max)
+              }
+              value={yAxisMaxInput}
+              onChange={(e) => onYAxisMaxInputChange(e.target.value)}
+              aria-label="Y-axis maximum"
+            />
+          </label>
+        </div>
+      </div>
+      </>
+      )}
+
+      <div className="FilterBox">
+        <div className="AxisControl">
+          <FaArrowRight size={30} className="AxisIcon" />
+          <div className="AxisFields">
+            <div className="AxisLabelRow">
+              <label htmlFor={xAxisId} className="BoxTitle">
+                Horizontal axis
+              </label>
+              <div className="ScaleToggle">
+                <button
+                  type="button"
+                  className={`ScaleBtn ${xAxisMode === "ranked" ? "is-active" : ""}`}
+                  onClick={() => onXAxisModeChange("ranked")}
+                >
+                  Ranked
+                </button>
+                <button
+                  type="button"
+                  className={`ScaleBtn ${xAxisMode === "scaled" ? "is-active" : ""}`}
+                  onClick={() =>
+                    xAxisKey !== "title" && onXAxisModeChange("scaled")
+                  }
+                  disabled={xAxisKey === "title"}
+                  title={
+                    xAxisKey === "title"
+                      ? "Not available for article title"
+                      : undefined
+                  }
+                >
+                  Scaled
+                </button>
+              </div>
+            </div>
+            <select
+              id={xAxisId}
+              className="SortSelect"
+              value={xAxisKey}
+              onChange={(e) => {
+                const key = e.target.value as XAxisKey;
+                onXAxisKeyChange(key);
+                onXAxisModeChange(key === "title" ? "ranked" : "scaled");
+              }}
+            >
+              <option value="title">Article title (A-Z)</option>
+              <option value="publication_date">Creation date (Old-New)</option>
+              <option value="linguistic_versions_count">
+                Linguistic versions (Low-High)
+              </option>
+              <option value="article_size">Article size (Small-Large)</option>
+              <option value="lead_section_size">
+                Lead section size (Small-Large)
+              </option>
+              <option value="talk_size">
+                Discussion page size (Small-Large)
+              </option>
+              <option value="warning_tags_count">
+                Warning tags (Low-High)
+              </option>
+              <option value="images_count">Images (Low-High)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AxisControls;

--- a/app/frontend/components/legend-modal.component.tsx
+++ b/app/frontend/components/legend-modal.component.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { MdLegendToggle } from "react-icons/md";
+import { IoClose } from "react-icons/io5";
+
+interface LegendModalProps {
+  onClose: () => void;
+}
+
+const LegendModal: React.FC<LegendModalProps> = ({ onClose }) => {
+  return (
+    <div
+      className="LegendModal"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="Panel">
+        <div className="Header">
+          <div className="TitleGroup">
+            <MdLegendToggle size={20} className="HeaderIcon" />
+            <h3 className="Title">Legend</h3>
+          </div>
+          <button
+            type="button"
+            className="Close"
+            onClick={onClose}
+            aria-label="Close legend"
+          >
+            <IoClose size={24} />
+          </button>
+        </div>
+        <div className="Body">
+          <img className="LegendImage" src="/images/legend.png" alt="Chart legend" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LegendModal;

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -113,6 +113,18 @@ const patchChartScales = (vgSpec: any) => {
     // lowering the domain would expose negative axis values.
     const yScale = scales.find((s: any) => s.name === "y");
     if (yScale && Array.isArray(yScale.range) && yScale.range.length === 2) {
+      if (!scales.some((s: any) => s.name === "y_grid")) {
+        const gridClone = { ...yScale, name: "y_grid" };
+        delete gridClone.domainRaw;
+        scales.push(gridClone);
+        vgSpec.scales = scales;
+      }
+      for (const axis of vgSpec.axes || []) {
+        if (axis.scale === "x" && axis.grid && axis.gridScale === "y") {
+          axis.gridScale = "y_grid";
+        }
+      }
+
       const bottom = yScale.range[0];
       const bottomExpr =
         bottom && typeof bottom === "object" && "signal" in bottom

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -723,12 +723,6 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     setCommittedYAxisMaxInput("");
   }, [yAxisKey]);
 
-  useEffect(() => {
-    if (xAxisKey === "title") {
-      setXAxisMode("ranked");
-    }
-  }, [xAxisKey]);
-
   sortedRowsRef.current = sortedRows;
   const hasData = sortedRows.length > 0;
   const isLargeDatasetBucket = sortedRows.length > LARGE_DATASET_THRESHOLD;
@@ -813,7 +807,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
 
     // Edge padding so the first/last bubble isn't clipped (the pan clamp
     // otherwise pins the domain flush to the data).
-    xEncoding.scale = { ...(xEncoding.scale || {}), padding: MAX_CIRCLE_RADIUS };
+    xEncoding.scale = {
+      ...(xEncoding.scale || {}),
+      padding: MAX_CIRCLE_RADIUS,
+    };
 
     const yFieldExpr = `datum[${JSON.stringify(yAxisConfig.currentField)}]`;
     const yFilterExprParts: string[] = [];
@@ -1638,7 +1635,11 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                   id="wiki-bubble-sort"
                   className="SortSelect"
                   value={xAxisKey}
-                  onChange={(e) => setXAxisKey(e.target.value as XAxisKey)}
+                  onChange={(e) => {
+                    const key = e.target.value as XAxisKey;
+                    setXAxisKey(key);
+                    setXAxisMode(key === "title" ? "ranked" : "scaled");
+                  }}
                 >
                   <option value="title">Article title (A-Z)</option>
                   <option value="publication_date">

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -15,8 +15,15 @@ import {
   BsImage,
   BsLink45Deg,
   BsCheck2,
+  BsEye,
+  BsEyeSlash,
 } from "react-icons/bs";
-import { FaArrowRight, FaArrowUp } from "react-icons/fa6";
+import {
+  FaArrowRight,
+  FaArrowUp,
+  FaChevronUp,
+  FaChevronDown,
+} from "react-icons/fa6";
 import CSVButton from "./CSV-button.component";
 import WikitextButton from "./wikitext-button.component";
 import ArticleSearchAutocomplete from "./article-search-autocomplete.component";
@@ -46,6 +53,8 @@ import { exportChartImage } from "../utils/chart-image-export";
 import {
   decodeChartState,
   encodeChartState,
+  DEFAULT_CHART_UI_STATE,
+  GRADE_KEYS,
 } from "../utils/bubble-chart-permalink";
 
 type Wiki = {
@@ -161,24 +170,37 @@ const gradeGroups = [
 function QualityFilterButtons({
   onToggle,
   selected,
+  onReset,
 }: {
   onToggle: (grades: string[], on: boolean) => void;
   selected: Record<string, boolean>;
+  onReset: () => void;
 }) {
   return (
     <div className="QualityAssessment">
-      <div className="BoxTitle">Quality assessment*</div>
-      <div className="Grid">
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by quality assessment*</div>
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset all
+        </button>
+      </div>
+      <div className="FilterList">
         {gradeGroups.map((g) => {
           const isOn = g.grades.every((x) => selected[x] !== false);
           return (
             <button
               key={g.id}
               type="button"
-              className={`Btn ${isOn ? "is-selected" : ""}`}
+              className={`FilterRow ${isOn ? "is-on" : "is-off"}`}
               data-group={g.id}
+              aria-pressed={isOn}
               onClick={() => onToggle(g.grades, !isOn)}
             >
+              {isOn ? (
+                <BsEye className="EyeIcon" />
+              ) : (
+                <BsEyeSlash className="EyeIcon" />
+              )}
               <span className="Dot" style={{ backgroundColor: g.dot }} />
               <span className="Label">{g.label}</span>
             </button>
@@ -194,21 +216,20 @@ function TagFilterButtons({
   deselected,
   includeUntagged,
   onToggle,
-  onToggleAll,
   onIncludeUntaggedChange,
+  onReset,
 }: {
   tags: string[];
   deselected: Set<string>;
   includeUntagged: boolean;
   onToggle: (tag: string, on: boolean) => void;
-  onToggleAll: (on: boolean) => void;
   onIncludeUntaggedChange: (checked: boolean) => void;
+  onReset: () => void;
 }) {
-  const allSelected = deselected.size === 0;
   return (
     <div className="TagFilter">
-      <div className="TagFilterHead">
-        <div className="BoxTitle">Tags</div>
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by tags</div>
         <label className="Checkbox">
           <input
             type="checkbox"
@@ -216,26 +237,28 @@ function TagFilterButtons({
             onChange={(e) => onIncludeUntaggedChange(e.target.checked)}
             aria-label="Include untagged articles"
           />
-          <span>include untagged articles</span>
+          <span>include untagged</span>
         </label>
-        <button
-          type="button"
-          className="ToggleAll"
-          onClick={() => onToggleAll(!allSelected)}
-        >
-          {allSelected ? "Deselect all" : "Select all"}
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset all
         </button>
       </div>
-      <div className="Grid">
+      <div className="FilterList">
         {tags.map((tag) => {
           const isOn = !deselected.has(tag);
           return (
             <button
               key={tag}
               type="button"
-              className={`Btn ${isOn ? "is-selected" : ""}`}
+              className={`FilterRow ${isOn ? "is-on" : "is-off"}`}
+              aria-pressed={isOn}
               onClick={() => onToggle(tag, !isOn)}
             >
+              {isOn ? (
+                <BsEye className="EyeIcon" />
+              ) : (
+                <BsEyeSlash className="EyeIcon" />
+              )}
               <span className="Label">{tag}</span>
             </button>
           );
@@ -250,32 +273,43 @@ function ProtectionFilterCheckboxes({
   editChecked,
   onMoveChange,
   onEditChange,
+  onReset,
 }: {
   moveChecked: boolean;
   editChecked: boolean;
   onMoveChange: (checked: boolean) => void;
   onEditChange: (checked: boolean) => void;
+  onReset: () => void;
 }) {
+  const rows = [
+    { label: "Move restriction", checked: moveChecked, onChange: onMoveChange },
+    { label: "Edit restriction", checked: editChecked, onChange: onEditChange },
+  ];
   return (
     <div className="ProtectionFilter">
-      <div className="BoxTitle">Protection filter</div>
-      <div className="Checkboxes">
-        <label className="Label">
-          <input
-            type="checkbox"
-            checked={moveChecked}
-            onChange={(e) => onMoveChange(e.target.checked)}
-          />
-          <span>Move restriction</span>
-        </label>
-        <label className="Label">
-          <input
-            type="checkbox"
-            checked={editChecked}
-            onChange={(e) => onEditChange(e.target.checked)}
-          />
-          <span>Edit restriction</span>
-        </label>
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by article protection</div>
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset
+        </button>
+      </div>
+      <div className="FilterList">
+        {rows.map((row) => (
+          <button
+            key={row.label}
+            type="button"
+            className={`FilterRow ${row.checked ? "is-on" : "is-off"}`}
+            aria-pressed={row.checked}
+            onClick={() => row.onChange(!row.checked)}
+          >
+            {row.checked ? (
+              <BsEye className="EyeIcon" />
+            ) : (
+              <BsEyeSlash className="EyeIcon" />
+            )}
+            <span className="Label">{row.label}</span>
+          </button>
+        ))}
       </div>
     </div>
   );
@@ -288,6 +322,7 @@ function CentralityFilter({
   onMinChange,
   onMaxChange,
   onIncludeUnassessedChange,
+  onReset,
 }: {
   min: number;
   max: number;
@@ -295,6 +330,7 @@ function CentralityFilter({
   onMinChange: (value: number) => void;
   onMaxChange: (value: number) => void;
   onIncludeUnassessedChange: (checked: boolean) => void;
+  onReset: () => void;
 }) {
   const minPercent =
     ((min - CENTRALITY_MIN) / (CENTRALITY_MAX - CENTRALITY_MIN)) * 100;
@@ -303,8 +339,8 @@ function CentralityFilter({
 
   return (
     <div className="CentralityFilter">
-      <div className="Header">
-        <div className="BoxTitle">Centrality</div>
+      <div className="FilterHead">
+        <div className="BoxTitle">Filter by centrality</div>
         <label className="Checkbox">
           <input
             type="checkbox"
@@ -314,9 +350,12 @@ function CentralityFilter({
           />
           <span>include articles without centrality</span>
         </label>
-        <div className="Value">
-          {min}-{max}
-        </div>
+        <button type="button" className="ResetLink" onClick={onReset}>
+          Reset
+        </button>
+      </div>
+      <div className="Value">
+        {min}-{max}
       </div>
       <div className="Slider">
         <div className="Track" />
@@ -346,8 +385,8 @@ function CentralityFilter({
         />
       </div>
       <div className="Bounds">
-        <span>{CENTRALITY_MIN}</span>
-        <span>{CENTRALITY_MAX}</span>
+        <span>{CENTRALITY_MIN} (min)</span>
+        <span>{CENTRALITY_MAX} (max)</span>
       </div>
     </div>
   );
@@ -420,6 +459,19 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   const [includeNoCentrality, setIncludeNoCentrality] = useState<boolean>(
     initialState.includeNoCentrality,
   );
+  const [advancedOpen, setAdvancedOpen] = useState<boolean>(() => {
+    const s = initialState;
+    return (
+      s.deselectedTags.length > 0 ||
+      !s.includeUntagged ||
+      s.centralityMin !== DEFAULT_CHART_UI_STATE.centralityMin ||
+      s.centralityMax !== DEFAULT_CHART_UI_STATE.centralityMax ||
+      !s.includeNoCentrality ||
+      s.filterMoveRestriction ||
+      s.filterEditRestriction ||
+      GRADE_KEYS.some((g) => s.selectedGrades[g] === false)
+    );
+  });
   const [searchTerm, setSearchTerm] = useState<string>(initialState.searchTerm);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
   const [selectedArticle, setSelectedArticle] = useState<ArticleRow | null>(
@@ -1348,6 +1400,27 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     startTransition(() => setIncludeNoCentrality(checked));
   };
 
+  const resetTags = () => {
+    toggleAllTags(true);
+    handleIncludeUntaggedChange(true);
+  };
+
+  const resetGrades = () => toggleGrades(GRADE_KEYS, true);
+
+  const resetCentrality = () => {
+    updateCentralitySignals(CENTRALITY_MIN, CENTRALITY_MAX, true);
+    startTransition(() => {
+      setCentralityMin(CENTRALITY_MIN);
+      setCentralityMax(CENTRALITY_MAX);
+      setIncludeNoCentrality(true);
+    });
+  };
+
+  const resetProtection = () => {
+    handleMoveRestrictionChange(false);
+    handleEditRestrictionChange(false);
+  };
+
   const handleShowLabelsChange = (checked: boolean) => {
     setShowLabels(checked);
   };
@@ -1529,6 +1602,21 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         >
           Languages
         </button>
+        {activeTab === "overview" && (
+          <button
+            type="button"
+            className="AdvancedToggle"
+            aria-expanded={advancedOpen}
+            onClick={() => setAdvancedOpen((open) => !open)}
+          >
+            <span className="AdvancedToggleLabel">Advanced Filters</span>
+            {advancedOpen ? (
+              <FaChevronUp size={14} />
+            ) : (
+              <FaChevronDown size={14} />
+            )}
+          </button>
+        )}
       </div>
 
       <div className="TabPanel" hidden={activeTab !== "overview"}>
@@ -1677,17 +1765,57 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               </div>
             </div>
           </div>
+        </div>
 
-          <div className="FilterBox">
-            <CentralityFilter
-              min={centralityMin}
-              max={centralityMax}
-              includeUnassessed={includeNoCentrality}
-              onMinChange={handleCentralityMinChange}
-              onMaxChange={handleCentralityMaxChange}
-              onIncludeUnassessedChange={handleIncludeNoCentralityChange}
-            />
-          </div>
+        <div className="AdvancedFilters">
+          {advancedOpen && (
+            <div
+              className={`AdvancedPanel ${availableTags.length ? "has-tags" : ""}`}
+            >
+              {availableTags.length > 0 && (
+                <div className="FilterBox FilterBox--tags">
+                  <TagFilterButtons
+                    tags={availableTags}
+                    deselected={deselectedTags}
+                    includeUntagged={includeUntagged}
+                    onToggle={toggleTag}
+                    onIncludeUntaggedChange={handleIncludeUntaggedChange}
+                    onReset={resetTags}
+                  />
+                </div>
+              )}
+
+              <div className="FilterBox">
+                <CentralityFilter
+                  min={centralityMin}
+                  max={centralityMax}
+                  includeUnassessed={includeNoCentrality}
+                  onMinChange={handleCentralityMinChange}
+                  onMaxChange={handleCentralityMaxChange}
+                  onIncludeUnassessedChange={handleIncludeNoCentralityChange}
+                  onReset={resetCentrality}
+                />
+              </div>
+
+              <div className="FilterBox FilterBox--quality">
+                <QualityFilterButtons
+                  onToggle={toggleGrades}
+                  selected={selectedGrades}
+                  onReset={resetGrades}
+                />
+              </div>
+
+              <div className="FilterBox">
+                <ProtectionFilterCheckboxes
+                  moveChecked={filterMoveRestriction}
+                  editChecked={filterEditRestriction}
+                  onMoveChange={handleMoveRestrictionChange}
+                  onEditChange={handleEditRestrictionChange}
+                  onReset={resetProtection}
+                />
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="Heading">
@@ -1724,39 +1852,6 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             onToggleOutlier={handleToggleOutlier}
             onClearOutliers={handleClearOutliers}
           />
-        </div>
-
-        <div
-          className={`QualityFilters ${availableTags.length ? "has-tags" : ""}`}
-        >
-          {availableTags.length > 0 && (
-            <div className="FilterBox FilterBox--tags">
-              <TagFilterButtons
-                tags={availableTags}
-                deselected={deselectedTags}
-                includeUntagged={includeUntagged}
-                onToggle={toggleTag}
-                onToggleAll={toggleAllTags}
-                onIncludeUntaggedChange={handleIncludeUntaggedChange}
-              />
-            </div>
-          )}
-
-          <div className="FilterBox">
-            <QualityFilterButtons
-              onToggle={toggleGrades}
-              selected={selectedGrades}
-            />
-          </div>
-
-          <div className="FilterBox">
-            <ProtectionFilterCheckboxes
-              moveChecked={filterMoveRestriction}
-              editChecked={filterEditRestriction}
-              onMoveChange={handleMoveRestrictionChange}
-              onEditChange={handleEditRestrictionChange}
-            />
-          </div>
         </div>
 
         <div className="Stats">
@@ -1827,8 +1922,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                 deselected={deselectedTags}
                 includeUntagged={includeUntagged}
                 onToggle={toggleTag}
-                onToggleAll={toggleAllTags}
                 onIncludeUntaggedChange={handleIncludeUntaggedChange}
+                onReset={resetTags}
               />
             </div>
           )}
@@ -1836,6 +1931,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             <QualityFilterButtons
               onToggle={toggleGrades}
               selected={selectedGrades}
+              onReset={resetGrades}
             />
           </div>
           <div className="FilterBox">
@@ -1844,6 +1940,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               editChecked={filterEditRestriction}
               onMoveChange={handleMoveRestrictionChange}
               onEditChange={handleEditRestrictionChange}
+              onReset={resetProtection}
             />
           </div>
         </div>

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -68,6 +68,67 @@ const LARGE_DATASET_THRESHOLD = 10000;
 const CENTRALITY_MIN = 1;
 const CENTRALITY_MAX = 10;
 
+// Largest bubble radius (Vega derives radius from area; max size range is 1500).
+const MAX_CIRCLE_RADIUS = Math.sqrt(1500 / Math.PI);
+const Y_BOTTOM_MARGIN = MAX_CIRCLE_RADIUS * 2;
+
+// Post-compile tweaks Vega-Lite can't express directly.
+const patchChartScales = (vgSpec: any) => {
+  try {
+    const scales = vgSpec.scales || [];
+
+    // Clamp x pan/zoom to the data extent (no dragging into empty space; no-op
+    // once every bubble is visible). The bound x domain is recomputed by
+    // panLinear/zoomLinear each frame, so we rewrite those to clamp at the
+    // source against `x_base` — the x scale without the interactive override.
+    const xScale = scales.find((s: any) => s.name === "x");
+    if (xScale && xScale.domainRaw) {
+      if (!scales.some((s: any) => s.name === "x_base")) {
+        const base = { ...xScale, name: "x_base" };
+        delete base.domainRaw;
+        scales.push(base);
+        vgSpec.scales = scales;
+      }
+      const B = "domain('x_base')";
+      const clamp = (proposed: string) =>
+        `(span(${proposed}) >= span(${B}) ? ${B}` +
+        ` : (${proposed})[0] < ${B}[0] ? [${B}[0], ${B}[0] + span(${proposed})]` +
+        ` : (${proposed})[1] > ${B}[1] ? [${B}[1] - span(${proposed}), ${B}[1]]` +
+        ` : (${proposed}))`;
+      for (const sig of vgSpec.signals || []) {
+        if (!Array.isArray(sig.on)) continue;
+        for (const handler of sig.on) {
+          if (
+            typeof handler.update === "string" &&
+            /panLinear|zoomLinear/.test(handler.update)
+          ) {
+            handler.update = clamp(handler.update);
+          }
+        }
+      }
+    }
+
+    // Inset the y range's bottom so low-value bubbles clear the floor. Done in
+    // pixel space: scale.padding is ignored once domainMin/Max are set, and
+    // lowering the domain would expose negative axis values.
+    const yScale = scales.find((s: any) => s.name === "y");
+    if (yScale && Array.isArray(yScale.range) && yScale.range.length === 2) {
+      const bottom = yScale.range[0];
+      const bottomExpr =
+        bottom && typeof bottom === "object" && "signal" in bottom
+          ? bottom.signal
+          : String(bottom);
+      yScale.range = [
+        { signal: `(${bottomExpr}) - ${Y_BOTTOM_MARGIN}` },
+        yScale.range[1],
+      ];
+    }
+  } catch {
+    // leave the spec untouched if the compiled shape is unexpected
+  }
+  return vgSpec;
+};
+
 const gradeGroups = [
   { id: "fa", label: "Featured", grades: ["FA", "FL"], dot: "#9CBDFF" },
   { id: "ga", label: "GA", grades: ["GA"], dot: "#66FF66" },
@@ -678,9 +739,6 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     const currentSortedRows = sortedRowsRef.current;
     const isLogScale = yAxisScaleType === "log";
 
-    // calculate padding based on maximum circle radius to prevent clipping
-    const maxCircleRadius = Math.sqrt(1500 / Math.PI); // this is how vega calculates the circle radius
-
     let yScaleSpec: Record<string, any>;
     if (isLogScale) {
       const logAutoMin =
@@ -698,16 +756,22 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         },
       };
     } else {
-      const fallbackMin = -25;
-      const fallbackMax = yAxisAutoDomain.max ?? 1000;
-      const fallbackRange = fallbackMax - fallbackMin;
-      const fallbackPadding = maxCircleRadius * (fallbackRange / HEIGHT);
+      // Fall back to the auto domain when no user range; clamp autoMin to 0.
+      const autoMin =
+        yAxisAutoDomain.min !== null ? Math.max(0, yAxisAutoDomain.min) : 0;
+      const autoMax = yAxisAutoDomain.max ?? 1000;
+      const loExpr = `(isFinite(y_domain_min) ? y_domain_min : ${autoMin})`;
+      const hiExpr = `(isFinite(y_domain_max) ? y_domain_max : ${autoMax})`;
+      // Radius padding in domain units so boundary bubbles stay visible; max(,1)
+      // guards a degenerate span; domainMin clamps to 0 (no below-zero axis).
+      const spanExpr = `max((${hiExpr}) - (${loExpr}), 1)`;
+      const padExpr = `(${MAX_CIRCLE_RADIUS} * (${spanExpr}) / ${HEIGHT})`;
       yScaleSpec = {
         domainMin: {
-          expr: `isFinite(y_domain_min) && y_domain_min > 0 ? y_domain_min : ${fallbackMin - fallbackPadding}`,
+          expr: `max(0, (${loExpr}) - ${padExpr})`,
         },
         domainMax: {
-          expr: `isFinite(y_domain_max) ? y_domain_max : ${fallbackMax + fallbackPadding}`,
+          expr: `(${hiExpr}) + ${padExpr}`,
         },
       };
     }
@@ -746,6 +810,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             grid: false,
           },
         };
+
+    // Edge padding so the first/last bubble isn't clipped (the pan clamp
+    // otherwise pins the domain flush to the data).
+    xEncoding.scale = { ...(xEncoding.scale || {}), padding: MAX_CIRCLE_RADIUS };
 
     const yFieldExpr = `datum[${JSON.stringify(yAxisConfig.currentField)}]`;
     const yFilterExprParts: string[] = [];
@@ -1074,6 +1142,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       actions,
       renderer: "canvas",
       mode: "vega-lite",
+      patch: patchChartScales as EmbedOptions["patch"],
       tooltip: {
         sanitize: (value: string) => value,
       } as EmbedOptions["tooltip"],

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -18,6 +18,7 @@ import {
   BsEye,
   BsEyeSlash,
 } from "react-icons/bs";
+import { MdLegendToggle } from "react-icons/md";
 import {
   FaArrowRight,
   FaArrowUp,
@@ -32,6 +33,7 @@ import FilteredArticlesSidebar from "./filtered-articles-sidebar.component";
 import ArticleLanguagesGrid from "./article-languages-grid.component";
 import ArticleLanguageComparisonModal from "./article-language-comparison-modal.component";
 import GlossaryModal from "./glossary-modal.component";
+import LegendModal from "./legend-modal.component";
 import type { ArticleRow } from "./article-detail-panel.component";
 import type {
   ArticleAnalytics,
@@ -484,6 +486,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     null,
   );
   const [glossaryOpen, setGlossaryOpen] = useState<boolean>(false);
+  const [legendOpen, setLegendOpen] = useState<boolean>(false);
   const [showLabels, setShowLabels] = useState<boolean>(
     initialState.showLabels,
   );
@@ -1580,6 +1583,14 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         <button
           type="button"
           className="GlossaryBtn"
+          onClick={() => setLegendOpen(true)}
+        >
+          <MdLegendToggle size={14} />
+          <span>Legend</span>
+        </button>
+        <button
+          type="button"
+          className="GlossaryBtn"
           onClick={() => setGlossaryOpen(true)}
         >
           <BsBook size={14} />
@@ -1898,16 +1909,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           </div>
         </div>
 
-        {/* Legend */}
-        <div className="Legend">
-          <div className="Text">
-            * Quality assessment is done by the Wikipedia community and it may
-            be inconsistent
-          </div>
-          <div className="Box">
-            <div className="Title">Legend</div>
-            <img src="/images/legend.png" />
-          </div>
+        <div className="Footnote">
+          * Quality assessment is done by the Wikipedia community and it may be
+          inconsistent
         </div>
       </div>
 
@@ -1999,6 +2003,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       )}
 
       {glossaryOpen && <GlossaryModal onClose={() => setGlossaryOpen(false)} />}
+
+      {legendOpen && <LegendModal onClose={() => setLegendOpen(false)} />}
     </div>
   );
 };

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -15,16 +15,9 @@ import {
   BsImage,
   BsLink45Deg,
   BsCheck2,
-  BsEye,
-  BsEyeSlash,
 } from "react-icons/bs";
 import { MdLegendToggle } from "react-icons/md";
-import {
-  FaArrowRight,
-  FaArrowUp,
-  FaChevronUp,
-  FaChevronDown,
-} from "react-icons/fa6";
+import { FaChevronUp, FaChevronDown } from "react-icons/fa6";
 import CSVButton from "./CSV-button.component";
 import WikitextButton from "./wikitext-button.component";
 import ArticleSearchAutocomplete from "./article-search-autocomplete.component";
@@ -34,6 +27,8 @@ import ArticleLanguagesGrid from "./article-languages-grid.component";
 import ArticleLanguageComparisonModal from "./article-language-comparison-modal.component";
 import GlossaryModal from "./glossary-modal.component";
 import LegendModal from "./legend-modal.component";
+import AdvancedFilterPanel from "./advanced-filter-panel.component";
+import AxisControls from "./axis-controls.component";
 import type { ArticleRow } from "./article-detail-panel.component";
 import type {
   ArticleAnalytics,
@@ -57,6 +52,8 @@ import {
   encodeChartState,
   DEFAULT_CHART_UI_STATE,
   GRADE_KEYS,
+  CENTRALITY_MIN,
+  CENTRALITY_MAX,
 } from "../utils/bubble-chart-permalink";
 
 type Wiki = {
@@ -76,8 +73,6 @@ interface WikiBubbleChartProps {
 
 const HEIGHT = 650;
 const LARGE_DATASET_THRESHOLD = 10000;
-const CENTRALITY_MIN = 1;
-const CENTRALITY_MAX = 10;
 
 // Largest bubble radius (Vega derives radius from area; max size range is 1500).
 const MAX_CIRCLE_RADIUS = Math.sqrt(1500 / Math.PI);
@@ -151,248 +146,6 @@ const patchChartScales = (vgSpec: any) => {
   }
   return vgSpec;
 };
-
-const gradeGroups = [
-  { id: "fa", label: "Featured", grades: ["FA", "FL"], dot: "#9CBDFF" },
-  { id: "ga", label: "GA", grades: ["GA"], dot: "#66FF66" },
-  { id: "aclass", label: "A-Class", grades: ["A"], dot: "#66FFFF" },
-  { id: "bclass", label: "B-Class", grades: ["B"], dot: "#B2FF66" },
-  { id: "cclass", label: "C-Class", grades: ["C"], dot: "#FFFF66" },
-  { id: "start", label: "Start", grades: ["Start"], dot: "#FFAA66" },
-  { id: "stub", label: "Stub", grades: ["Stub"], dot: "#FFA4A4" },
-  { id: "list", label: "List", grades: ["List"], dot: "#C7B1FF" },
-  {
-    id: "unassessed",
-    label: "Unassessed",
-    grades: ["Unassessed"],
-    dot: "#9E9E9E",
-  },
-];
-
-function QualityFilterButtons({
-  onToggle,
-  selected,
-  onReset,
-}: {
-  onToggle: (grades: string[], on: boolean) => void;
-  selected: Record<string, boolean>;
-  onReset: () => void;
-}) {
-  return (
-    <div className="QualityAssessment">
-      <div className="FilterHead">
-        <div className="BoxTitle">Filter by quality assessment*</div>
-        <button type="button" className="ResetLink" onClick={onReset}>
-          Reset all
-        </button>
-      </div>
-      <div className="FilterList">
-        {gradeGroups.map((g) => {
-          const isOn = g.grades.every((x) => selected[x] !== false);
-          return (
-            <button
-              key={g.id}
-              type="button"
-              className={`FilterRow ${isOn ? "is-on" : "is-off"}`}
-              data-group={g.id}
-              aria-pressed={isOn}
-              onClick={() => onToggle(g.grades, !isOn)}
-            >
-              {isOn ? (
-                <BsEye className="EyeIcon" />
-              ) : (
-                <BsEyeSlash className="EyeIcon" />
-              )}
-              <span className="Dot" style={{ backgroundColor: g.dot }} />
-              <span className="Label">{g.label}</span>
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function TagFilterButtons({
-  tags,
-  deselected,
-  includeUntagged,
-  onToggle,
-  onIncludeUntaggedChange,
-  onReset,
-}: {
-  tags: string[];
-  deselected: Set<string>;
-  includeUntagged: boolean;
-  onToggle: (tag: string, on: boolean) => void;
-  onIncludeUntaggedChange: (checked: boolean) => void;
-  onReset: () => void;
-}) {
-  return (
-    <div className="TagFilter">
-      <div className="FilterHead">
-        <div className="BoxTitle">Filter by tags</div>
-        <label className="Checkbox">
-          <input
-            type="checkbox"
-            checked={includeUntagged}
-            onChange={(e) => onIncludeUntaggedChange(e.target.checked)}
-            aria-label="Include untagged articles"
-          />
-          <span>include untagged</span>
-        </label>
-        <button type="button" className="ResetLink" onClick={onReset}>
-          Reset all
-        </button>
-      </div>
-      <div className="FilterList">
-        {tags.map((tag) => {
-          const isOn = !deselected.has(tag);
-          return (
-            <button
-              key={tag}
-              type="button"
-              className={`FilterRow ${isOn ? "is-on" : "is-off"}`}
-              aria-pressed={isOn}
-              onClick={() => onToggle(tag, !isOn)}
-            >
-              {isOn ? (
-                <BsEye className="EyeIcon" />
-              ) : (
-                <BsEyeSlash className="EyeIcon" />
-              )}
-              <span className="Label">{tag}</span>
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function ProtectionFilterCheckboxes({
-  moveChecked,
-  editChecked,
-  onMoveChange,
-  onEditChange,
-  onReset,
-}: {
-  moveChecked: boolean;
-  editChecked: boolean;
-  onMoveChange: (checked: boolean) => void;
-  onEditChange: (checked: boolean) => void;
-  onReset: () => void;
-}) {
-  const rows = [
-    { label: "Move restriction", checked: moveChecked, onChange: onMoveChange },
-    { label: "Edit restriction", checked: editChecked, onChange: onEditChange },
-  ];
-  return (
-    <div className="ProtectionFilter">
-      <div className="FilterHead">
-        <div className="BoxTitle">Filter by article protection</div>
-        <button type="button" className="ResetLink" onClick={onReset}>
-          Reset
-        </button>
-      </div>
-      <div className="FilterList">
-        {rows.map((row) => (
-          <button
-            key={row.label}
-            type="button"
-            className={`FilterRow ${row.checked ? "is-on" : "is-off"}`}
-            aria-pressed={row.checked}
-            onClick={() => row.onChange(!row.checked)}
-          >
-            {row.checked ? (
-              <BsEye className="EyeIcon" />
-            ) : (
-              <BsEyeSlash className="EyeIcon" />
-            )}
-            <span className="Label">{row.label}</span>
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function CentralityFilter({
-  min,
-  max,
-  includeUnassessed,
-  onMinChange,
-  onMaxChange,
-  onIncludeUnassessedChange,
-  onReset,
-}: {
-  min: number;
-  max: number;
-  includeUnassessed: boolean;
-  onMinChange: (value: number) => void;
-  onMaxChange: (value: number) => void;
-  onIncludeUnassessedChange: (checked: boolean) => void;
-  onReset: () => void;
-}) {
-  const minPercent =
-    ((min - CENTRALITY_MIN) / (CENTRALITY_MAX - CENTRALITY_MIN)) * 100;
-  const maxPercent =
-    ((max - CENTRALITY_MIN) / (CENTRALITY_MAX - CENTRALITY_MIN)) * 100;
-
-  return (
-    <div className="CentralityFilter">
-      <div className="FilterHead">
-        <div className="BoxTitle">Filter by centrality</div>
-        <label className="Checkbox">
-          <input
-            type="checkbox"
-            checked={includeUnassessed}
-            onChange={(e) => onIncludeUnassessedChange(e.target.checked)}
-            aria-label="Include articles with no centrality"
-          />
-          <span>include articles without centrality</span>
-        </label>
-        <button type="button" className="ResetLink" onClick={onReset}>
-          Reset
-        </button>
-      </div>
-      <div className="Value">
-        {min}-{max}
-      </div>
-      <div className="Slider">
-        <div className="Track" />
-        <div
-          className="Range"
-          style={{ left: `${minPercent}%`, right: `${100 - maxPercent}%` }}
-        />
-        <input
-          type="range"
-          min={CENTRALITY_MIN}
-          max={CENTRALITY_MAX}
-          step={1}
-          value={min}
-          onChange={(e) => onMinChange(Number(e.target.value))}
-          aria-label="Minimum centrality"
-          className="Input Input--min"
-        />
-        <input
-          type="range"
-          min={CENTRALITY_MIN}
-          max={CENTRALITY_MAX}
-          step={1}
-          value={max}
-          onChange={(e) => onMaxChange(Number(e.target.value))}
-          aria-label="Maximum centrality"
-          className="Input Input--max"
-        />
-      </div>
-      <div className="Bounds">
-        <span>{CENTRALITY_MIN} (min)</span>
-        <span>{CENTRALITY_MAX} (max)</span>
-      </div>
-    </div>
-  );
-}
 
 export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   data = {},
@@ -1424,6 +1177,46 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     handleEditRestrictionChange(false);
   };
 
+  const advancedFilterProps = {
+    tags: availableTags,
+    deselectedTags,
+    includeUntagged,
+    onToggleTag: toggleTag,
+    onIncludeUntaggedChange: handleIncludeUntaggedChange,
+    onResetTags: resetTags,
+    centralityMin,
+    centralityMax,
+    includeNoCentrality,
+    onCentralityMinChange: handleCentralityMinChange,
+    onCentralityMaxChange: handleCentralityMaxChange,
+    onIncludeNoCentralityChange: handleIncludeNoCentralityChange,
+    onResetCentrality: resetCentrality,
+    selectedGrades,
+    onToggleGrades: toggleGrades,
+    onResetGrades: resetGrades,
+    moveRestriction: filterMoveRestriction,
+    editRestriction: filterEditRestriction,
+    onMoveRestrictionChange: handleMoveRestrictionChange,
+    onEditRestrictionChange: handleEditRestrictionChange,
+    onResetProtection: resetProtection,
+  };
+
+  const axisControlProps = {
+    yAxisKey,
+    onYAxisKeyChange: setYAxisKey,
+    yAxisScaleType,
+    onYAxisScaleTypeChange: setYAxisScaleType,
+    yAxisMinInput,
+    onYAxisMinInputChange: setYAxisMinInput,
+    yAxisMaxInput,
+    onYAxisMaxInputChange: setYAxisMaxInput,
+    yAxisAutoDomain,
+    xAxisKey,
+    onXAxisKeyChange: setXAxisKey,
+    xAxisMode,
+    onXAxisModeChange: setXAxisMode,
+  };
+
   const handleShowLabelsChange = (checked: boolean) => {
     setShowLabels(checked);
   };
@@ -1613,220 +1406,26 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         >
           Languages
         </button>
-        {activeTab === "overview" && (
-          <button
-            type="button"
-            className="AdvancedToggle"
-            aria-expanded={advancedOpen}
-            onClick={() => setAdvancedOpen((open) => !open)}
-          >
-            <span className="AdvancedToggleLabel">Advanced Filters</span>
-            {advancedOpen ? (
-              <FaChevronUp size={14} />
-            ) : (
-              <FaChevronDown size={14} />
-            )}
-          </button>
-        )}
+        <button
+          type="button"
+          className="AdvancedToggle"
+          aria-expanded={advancedOpen}
+          onClick={() => setAdvancedOpen((open) => !open)}
+        >
+          <span className="AdvancedToggleLabel">Advanced Filters</span>
+          {advancedOpen ? (
+            <FaChevronUp size={14} />
+          ) : (
+            <FaChevronDown size={14} />
+          )}
+        </button>
       </div>
 
       <div className="TabPanel" hidden={activeTab !== "overview"}>
-        <div className="AxisControls">
-          <div className="FilterBox">
-            <div className="AxisControl">
-              <FaArrowUp size={30} className="AxisIcon" />
-              <div className="AxisFields">
-                <div className="AxisLabelRow">
-                  <label htmlFor="wiki-bubble-y-axis" className="BoxTitle">
-                    Vertical axis
-                  </label>
-                  <div className="ScaleToggle">
-                    <button
-                      type="button"
-                      className={`ScaleBtn ${yAxisScaleType === "linear" ? "is-active" : ""}`}
-                      onClick={() => setYAxisScaleType("linear")}
-                    >
-                      Linear
-                    </button>
-                    <button
-                      type="button"
-                      className={`ScaleBtn ${yAxisScaleType === "log" ? "is-active" : ""}`}
-                      onClick={() => setYAxisScaleType("log")}
-                    >
-                      Log
-                    </button>
-                  </div>
-                </div>
-                <select
-                  id="wiki-bubble-y-axis"
-                  className="SortSelect"
-                  value={yAxisKey}
-                  onChange={(e) => setYAxisKey(e.target.value as YAxisKey)}
-                >
-                  <option value="average_daily_views">Avg daily views</option>
-                  <option value="number_of_editors">Editors</option>
-                  <option value="incoming_links_count">Incoming links</option>
-                </select>
-              </div>
-            </div>
-          </div>
-
-          <div className="FilterBox">
-            <div className="BoxTitle">Y-axis range</div>
-            <div className="RangeRow">
-              <label className="RangeField">
-                <span className="RangeLabel">min</span>
-                <input
-                  className="RangeInput"
-                  type="number"
-                  inputMode="numeric"
-                  placeholder={
-                    yAxisAutoDomain.min === null
-                      ? ""
-                      : String(yAxisAutoDomain.min)
-                  }
-                  value={yAxisMinInput}
-                  onChange={(e) => setYAxisMinInput(e.target.value)}
-                  aria-label="Y-axis minimum"
-                />
-              </label>
-              <label className="RangeField">
-                <span className="RangeLabel">max</span>
-                <input
-                  className="RangeInput"
-                  type="number"
-                  inputMode="numeric"
-                  placeholder={
-                    yAxisAutoDomain.max === null
-                      ? ""
-                      : String(yAxisAutoDomain.max)
-                  }
-                  value={yAxisMaxInput}
-                  onChange={(e) => setYAxisMaxInput(e.target.value)}
-                  aria-label="Y-axis maximum"
-                />
-              </label>
-            </div>
-          </div>
-
-          <div className="FilterBox">
-            <div className="AxisControl">
-              <FaArrowRight size={30} className="AxisIcon" />
-              <div className="AxisFields">
-                <div className="AxisLabelRow">
-                  <label htmlFor="wiki-bubble-sort" className="BoxTitle">
-                    Horizontal axis
-                  </label>
-                  <div className="ScaleToggle">
-                    <button
-                      type="button"
-                      className={`ScaleBtn ${xAxisMode === "ranked" ? "is-active" : ""}`}
-                      onClick={() => setXAxisMode("ranked")}
-                    >
-                      Ranked
-                    </button>
-                    <button
-                      type="button"
-                      className={`ScaleBtn ${xAxisMode === "scaled" ? "is-active" : ""}`}
-                      onClick={() =>
-                        xAxisKey !== "title" && setXAxisMode("scaled")
-                      }
-                      disabled={xAxisKey === "title"}
-                      title={
-                        xAxisKey === "title"
-                          ? "Not available for article title"
-                          : undefined
-                      }
-                    >
-                      Scaled
-                    </button>
-                  </div>
-                </div>
-                <select
-                  id="wiki-bubble-sort"
-                  className="SortSelect"
-                  value={xAxisKey}
-                  onChange={(e) => {
-                    const key = e.target.value as XAxisKey;
-                    setXAxisKey(key);
-                    setXAxisMode(key === "title" ? "ranked" : "scaled");
-                  }}
-                >
-                  <option value="title">Article title (A-Z)</option>
-                  <option value="publication_date">
-                    Creation date (Old-New)
-                  </option>
-                  <option value="linguistic_versions_count">
-                    Linguistic versions (Low-High)
-                  </option>
-                  <option value="article_size">
-                    Article size (Small-Large)
-                  </option>
-                  <option value="lead_section_size">
-                    Lead section size (Small-Large)
-                  </option>
-                  <option value="talk_size">
-                    Discussion page size (Small-Large)
-                  </option>
-                  <option value="warning_tags_count">
-                    Warning tags (Low-High)
-                  </option>
-                  <option value="images_count">Images (Low-High)</option>
-                </select>
-              </div>
-            </div>
-          </div>
-        </div>
+        <AxisControls idPrefix="overview" {...axisControlProps} />
 
         <div className="AdvancedFilters">
-          {advancedOpen && (
-            <div
-              className={`AdvancedPanel ${availableTags.length ? "has-tags" : ""}`}
-            >
-              {availableTags.length > 0 && (
-                <div className="FilterBox FilterBox--tags">
-                  <TagFilterButtons
-                    tags={availableTags}
-                    deselected={deselectedTags}
-                    includeUntagged={includeUntagged}
-                    onToggle={toggleTag}
-                    onIncludeUntaggedChange={handleIncludeUntaggedChange}
-                    onReset={resetTags}
-                  />
-                </div>
-              )}
-
-              <div className="FilterBox">
-                <CentralityFilter
-                  min={centralityMin}
-                  max={centralityMax}
-                  includeUnassessed={includeNoCentrality}
-                  onMinChange={handleCentralityMinChange}
-                  onMaxChange={handleCentralityMaxChange}
-                  onIncludeUnassessedChange={handleIncludeNoCentralityChange}
-                  onReset={resetCentrality}
-                />
-              </div>
-
-              <div className="FilterBox FilterBox--quality">
-                <QualityFilterButtons
-                  onToggle={toggleGrades}
-                  selected={selectedGrades}
-                  onReset={resetGrades}
-                />
-              </div>
-
-              <div className="FilterBox">
-                <ProtectionFilterCheckboxes
-                  moveChecked={filterMoveRestriction}
-                  editChecked={filterEditRestriction}
-                  onMoveChange={handleMoveRestrictionChange}
-                  onEditChange={handleEditRestrictionChange}
-                  onReset={resetProtection}
-                />
-              </div>
-            </div>
-          )}
+          {advancedOpen && <AdvancedFilterPanel {...advancedFilterProps} />}
         </div>
 
         <div className="Heading">
@@ -1916,37 +1515,10 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       </div>
 
       <div className="TabPanel" hidden={activeTab !== "languages"}>
-        <div
-          className={`QualityFilters ${availableTags.length ? "has-tags" : ""}`}
-        >
-          {availableTags.length > 0 && (
-            <div className="FilterBox FilterBox--tags">
-              <TagFilterButtons
-                tags={availableTags}
-                deselected={deselectedTags}
-                includeUntagged={includeUntagged}
-                onToggle={toggleTag}
-                onIncludeUntaggedChange={handleIncludeUntaggedChange}
-                onReset={resetTags}
-              />
-            </div>
-          )}
-          <div className="FilterBox">
-            <QualityFilterButtons
-              onToggle={toggleGrades}
-              selected={selectedGrades}
-              onReset={resetGrades}
-            />
-          </div>
-          <div className="FilterBox">
-            <ProtectionFilterCheckboxes
-              moveChecked={filterMoveRestriction}
-              editChecked={filterEditRestriction}
-              onMoveChange={handleMoveRestrictionChange}
-              onEditChange={handleEditRestrictionChange}
-              onReset={resetProtection}
-            />
-          </div>
+        <AxisControls idPrefix="languages" hideYAxis {...axisControlProps} />
+
+        <div className="AdvancedFilters">
+          {advancedOpen && <AdvancedFilterPanel {...advancedFilterProps} />}
         </div>
 
         <div className="ArticleLang">

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -1503,6 +1503,45 @@ $danger-fg: #c62828;
 
     .HeaderLang {
       width: 1fr;
+      cursor: grab;
+      user-select: none;
+      position: relative;
+
+      &--dragging {
+        opacity: 0.4;
+        background: #e3f2fd;
+      }
+
+      &--dragover {
+        border-left: 4px solid $primary;
+        background: #e3f2fd;
+
+        .DragHandle {
+          color: $primary;
+        }
+      }
+
+      &-inner {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+      }
+
+      .DragHandle {
+        color: lightgrey;
+        cursor: grab;
+        flex-shrink: 0;
+        position: absolute;
+        left: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      &:active,
+      &:active .DragHandle {
+        cursor: grabbing;
+      }
     }
   }
 
@@ -1718,8 +1757,8 @@ $danger-fg: #c62828;
 
   .Panel {
     background: white;
-    width: 90vw;
-    max-width: 1100px;
+    width: 95vw;
+    max-width: 1500px;
     max-height: 85vh;
     display: flex;
     flex-direction: column;
@@ -1789,50 +1828,90 @@ $danger-fg: #c62828;
     border-collapse: collapse;
     table-layout: fixed;
 
-    .MetricHeader {
+    .CornerHeader {
       width: 200px;
       background: white;
       border: 1px solid $border-faint;
     }
 
-    .LangHeader {
-      padding: 12px 16px;
+    .MetricHeader {
+      padding: 12px 14px;
       font-size: 13px;
       font-weight: 600;
       color: $text-strong;
       text-align: center;
       background: white;
       border: 1px solid $border-faint;
+    }
 
-      span {
-        margin-right: 4px;
+    .LangRow {
+      cursor: grab;
+
+      &--dragging {
+        opacity: 0.4;
+        background: #e3f2fd;
       }
+
+      &--dragover {
+        background: #e3f2fd;
+
+        td,
+        th {
+          border-top: 3px solid $primary;
+        }
+
+        .DragHandle {
+          color: $primary;
+        }
+      }
+
+      &:active {
+        cursor: grabbing;
+      }
+    }
+
+    .LangHeader {
+      width: 200px;
+      padding: 12px 16px;
+      font-size: 13px;
+      font-weight: 600;
+      color: $text-strong;
+      text-align: left;
+      background: white;
+      border: 1px solid $border-faint;
+      user-select: none;
 
       &--missing {
         background: $danger-bg;
         color: $danger-fg;
       }
 
+      &-inner {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .DragHandle {
+        color: lightgrey;
+        cursor: grab;
+        flex-shrink: 0;
+      }
+
+      .LangName {
+        margin-right: auto;
+      }
+
       .Link {
         color: inherit;
         display: inline-flex;
         align-items: center;
-        vertical-align: middle;
+        flex-shrink: 0;
 
         &:hover {
           color: $primary-dark;
         }
       }
-    }
-
-    .MetricLabel {
-      padding: 12px 16px;
-      font-size: 13px;
-      font-weight: 500;
-      color: #555;
-      border: 1px solid $border-faint;
-      background: #fafafa;
-      white-space: nowrap;
     }
 
     .Cell {
@@ -1844,10 +1923,6 @@ $danger-fg: #c62828;
         text-align: center;
       }
 
-      &--translate {
-        padding: 8px 12px;
-      }
-
       .MissingIcon {
         color: $danger-fg;
         display: flex;
@@ -1857,20 +1932,17 @@ $danger-fg: #c62828;
 
       .Inner {
         display: flex;
-        align-items: center;
-        gap: 10px;
+        flex-direction: column;
+        gap: 6px;
 
         .Value {
           font-size: 13px;
           font-weight: 500;
           color: #333;
-          min-width: 64px;
-          text-align: right;
         }
 
         .Track {
-          flex: 1;
-          height: 16px;
+          height: 14px;
           background: #f0f0f0;
           border-radius: 2px;
 

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -328,6 +328,18 @@ $danger-fg: #c62828;
     .GlossaryBtn {
       margin-left: auto;
     }
+
+    .GlossaryBtn ~ .GlossaryBtn {
+      margin-left: 0;
+    }
+  }
+
+  .Footnote {
+    padding: 8px 12px;
+    border-top: 1px solid $border-grey;
+    font-size: 14px;
+    font-style: italic;
+    color: $text-secondary;
   }
 
   .SearchContainer {
@@ -421,75 +433,6 @@ $danger-fg: #c62828;
     font-size: 12px;
     color: $text-secondary;
     line-height: 1.3;
-  }
-
-  .Legend {
-    display: flex;
-    justify-content: space-between;
-    padding: 8px 12px;
-    margin-top: 8px;
-    gap: 16px;
-    flex-wrap: wrap;
-    align-items: center;
-    font-size: 0.9rem;
-
-    .Item {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-    }
-
-    .DotArticle,
-    .DotLead,
-    .RingDiscussion,
-    .RingPrevArticle {
-      display: inline-block;
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-    }
-
-    .DotArticle {
-      background-color: rgba(13, 71, 161, 0.5);
-    }
-
-    .DotLead {
-      background-color: #90caf9;
-    }
-
-    .RingDiscussion {
-      border: 2px solid #2196f3;
-      background-color: transparent;
-    }
-
-    .RingPrevArticle {
-      border: 2px dashed #64b5f6;
-      background-color: transparent;
-    }
-
-    .LineChange {
-      display: inline-block;
-      width: 16px;
-      height: 0;
-      border-top: 2px dashed #757575;
-    }
-
-    .Box {
-      border: 1px solid #ccc;
-      padding: 12px 16px;
-    }
-
-    .Title {
-      font-weight: bold;
-      font-size: 14px;
-      margin-bottom: 8px;
-    }
-
-    .Text {
-      font-size: 14px;
-      font-style: italic;
-      align-self: flex-start;
-    }
   }
 
   .TabBar {
@@ -1992,7 +1935,8 @@ $danger-fg: #c62828;
   }
 }
 
-.GlossaryModal {
+.GlossaryModal,
+.LegendModal {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.5);
@@ -2113,5 +2057,14 @@ $danger-fg: #c62828;
       color: $text-secondary;
       line-height: 1.5;
     }
+  }
+}
+
+.LegendModal {
+  .LegendImage {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 0 auto;
   }
 }

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -1697,6 +1697,7 @@ $danger-fg: #c62828;
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 1000;
 
   .Panel {
     background: white;

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -21,25 +21,6 @@ $danger-fg: #c62828;
   border: 1px solid $border-light;
   width: 100%;
 
-  .QualityFilters {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1px;
-    background: $border-grey;
-    border-top: 1px solid $border-grey;
-    align-items: stretch;
-
-    @media (min-width: 768px) {
-      grid-template-columns: 1fr 1fr;
-    }
-
-    &.has-tags {
-      @media (min-width: 768px) {
-        grid-template-columns: 1fr 2fr 1fr;
-      }
-    }
-  }
-
   .AdvancedToggle {
     margin-left: auto;
     display: flex;
@@ -126,6 +107,10 @@ $danger-fg: #c62828;
 
     @media (min-width: 768px) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    &.AxisControls--horizontalOnly {
+      grid-template-columns: 1fr;
     }
   }
 

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -40,6 +40,82 @@ $danger-fg: #c62828;
     }
   }
 
+  .AdvancedToggle {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    color: $text-strong;
+
+    &:hover {
+      background: #eeeeee;
+    }
+  }
+
+  .AdvancedPanel {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1px;
+    background: $border-grey;
+    border-top: 1px solid $border-grey;
+    border-bottom: 1px solid $border-grey;
+    align-items: stretch;
+
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    @media (min-width: 1200px) {
+      grid-template-columns: minmax(0, 1.3fr) minmax(0, 2.2fr) minmax(0, 0.9fr);
+    }
+
+    &.has-tags {
+      @media (min-width: 1200px) {
+        grid-template-columns:
+          minmax(0, 1.1fr) minmax(0, 1.3fr) minmax(0, 2.2fr)
+          minmax(0, 0.8fr);
+      }
+    }
+
+    .TagFilter,
+    .QualityAssessment,
+    .ProtectionFilter {
+      flex: 1;
+      min-height: 0;
+    }
+
+    .FilterBox {
+      min-height: 130px;
+    }
+
+    .FilterList {
+      flex: 1 1 0;
+      min-height: 0;
+      max-height: none;
+    }
+
+    .QualityAssessment .FilterList {
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-content: start;
+    }
+
+    .QualityAssessment .FilterRow {
+      flex: 1 1 18%;
+    }
+
+    .FilterBox--tags,
+    .FilterBox--quality {
+      padding-bottom: 0;
+    }
+  }
+
   .AxisControls {
     display: grid;
     grid-template-columns: 1fr;
@@ -49,11 +125,7 @@ $danger-fg: #c62828;
     align-items: stretch;
 
     @media (min-width: 768px) {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    @media (min-width: 1024px) {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 
@@ -422,6 +494,7 @@ $danger-fg: #c62828;
 
   .TabBar {
     display: flex;
+    align-items: center;
     border-bottom: 1px solid $border-grey;
   }
 
@@ -454,26 +527,11 @@ $danger-fg: #c62828;
 }
 
 .CentralityFilter {
-  display: grid;
-  grid-template-rows: auto auto;
-  gap: 0;
-  height: 100%;
-
-  .Header {
-    display: flex;
-    align-items: baseline;
-    justify-content: flex-start;
-    gap: 8px;
-    background: none;
-    border-bottom: none;
-
-    .BoxTitle {
-      flex: 0 0 auto;
-    }
-  }
+  display: flex;
+  flex-direction: column;
 
   .Value {
-    margin-left: auto;
+    align-self: flex-end;
     font-size: 13px;
     font-weight: 600;
     font-variant-numeric: tabular-nums;
@@ -611,7 +669,7 @@ $danger-fg: #c62828;
     display: flex;
     align-items: center;
     gap: 6px;
-    margin-bottom: 0;
+    margin-bottom: 8px;
     font-size: 12px;
     font-weight: 400;
     line-height: 1.2;
@@ -625,122 +683,128 @@ $danger-fg: #c62828;
   }
 }
 
-.QualityAssessment {
-  .Title {
-    font-weight: 600;
-    margin-bottom: 6px;
-    font-size: 14px;
+.FilterHead {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  margin-bottom: 8px;
+
+  .BoxTitle {
+    margin-bottom: 0;
   }
 
-  .Grid {
-    display: grid;
-    grid-template-columns: repeat(20, minmax(0, 1fr));
-    gap: 8px 12px;
-
-    .Btn:nth-child(-n + 5) {
-      grid-column: span 4;
-    }
-
-    .Btn:nth-child(n + 6) {
-      grid-column: span 5;
-    }
+  .Checkbox {
+    margin-bottom: 0;
   }
 
-  .Btn {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    width: 100%;
-    box-sizing: border-box;
-    padding: 6px 10px;
-    border: 1px solid $border-grey;
-    border-radius: 6px;
-    background: #fff;
-    cursor: pointer;
-    transition:
-      background-color 120ms ease,
-      border-color 120ms ease,
-      box-shadow 120ms ease;
+  .ResetLink {
+    margin-left: auto;
+  }
+}
 
-    &:hover {
-      border-color: #bdbdbd;
-    }
+.ResetLink {
+  flex: 0 0 auto;
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 12px;
+  color: #2a6f6a;
+  cursor: pointer;
+  white-space: nowrap;
 
-    &.is-selected {
-      background-color: #cfe9e7;
-      border-color: #b6deda;
-    }
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.FilterList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 76px;
+  overflow-y: auto;
+}
+
+.FilterRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 10px;
+  border: 1px solid $border-grey;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  color: $text-strong;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
+
+  &:hover {
+    border-color: #bdbdbd;
+  }
+
+  .EyeIcon {
+    flex: 0 0 auto;
+    font-size: 15px;
+    color: $text-secondary;
   }
 
   .Dot {
+    flex: 0 0 auto;
     width: 14px;
     height: 14px;
     border-radius: 3px;
-    display: inline-block;
   }
 
   .Label {
-    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &.is-on {
+    background: #cfe9e7;
+    border-color: #9fd3ce;
+    color: #1f4f4a;
+    font-weight: 500;
+
+    .EyeIcon {
+      color: #2a8079;
+    }
+
+    &:hover {
+      border-color: #6fc0b8;
+    }
+  }
+
+  &.is-off {
+    color: $text-muted;
+    background: #fafafa;
+
+    .EyeIcon {
+      color: #bdbdbd;
+    }
+
+    .Dot {
+      opacity: 0.35;
+    }
   }
 }
 
+.QualityAssessment,
 .ProtectionFilter {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  height: 100%;
-
-  > .BoxTitle {
-    margin-bottom: 6px;
-  }
-
-  .Checkboxes {
-    display: flex;
-    flex-direction: row;
-    gap: 8px;
-    align-self: center;
-  }
-
-  .Label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 14px;
-    font-weight: 400;
-    cursor: pointer;
-    padding: 2px 10px;
-    margin-bottom: 0;
-    border: 1px solid $border-grey;
-    border-radius: 6px;
-    background: #fff;
-    transition:
-      background-color 120ms ease,
-      border-color 120ms ease;
-
-    &:hover {
-      border-color: #bdbdbd;
-      background-color: #f5f5f5;
-    }
-
-    input[type="checkbox"] {
-      cursor: pointer;
-      border-radius: 6px;
-    }
-  }
+  display: flex;
+  flex-direction: column;
 }
 
 .TagFilter {
-  .TagFilterHead {
-    display: flex;
-    align-items: baseline;
-    justify-content: flex-start;
-    gap: 12px;
-    margin-bottom: 6px;
-
-    .BoxTitle {
-      flex: 0 0 auto;
-      margin-bottom: 0;
-    }
-  }
+  display: flex;
+  flex-direction: column;
 
   .Checkbox {
     display: flex;
@@ -756,55 +820,6 @@ $danger-fg: #c62828;
       height: 13px;
       margin: 0;
     }
-  }
-
-  .ToggleAll {
-    margin-left: auto;
-    border: none;
-    background: none;
-    padding: 0;
-    font-size: 12px;
-    color: #2a6f6a;
-    cursor: pointer;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  .Grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    max-height: 76px;
-    overflow-y: auto;
-  }
-
-  .Btn {
-    display: flex;
-    align-items: center;
-    box-sizing: border-box;
-    padding: 6px 10px;
-    border: 1px solid $border-grey;
-    border-radius: 6px;
-    background: #fff;
-    cursor: pointer;
-    transition:
-      background-color 120ms ease,
-      border-color 120ms ease;
-
-    &:hover {
-      border-color: #bdbdbd;
-    }
-
-    &.is-selected {
-      background-color: #cfe9e7;
-      border-color: #b6deda;
-    }
-  }
-
-  .Label {
-    font-size: 13px;
   }
 }
 

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -1829,7 +1829,7 @@ $danger-fg: #c62828;
     table-layout: fixed;
 
     .CornerHeader {
-      width: 200px;
+      width: 300px;
       background: white;
       border: 1px solid $border-faint;
     }
@@ -1871,8 +1871,8 @@ $danger-fg: #c62828;
     }
 
     .LangHeader {
-      width: 200px;
-      padding: 12px 16px;
+      width: 300px;
+      padding: 14px 16px;
       font-size: 13px;
       font-weight: 600;
       color: $text-strong;
@@ -1881,25 +1881,17 @@ $danger-fg: #c62828;
       border: 1px solid $border-faint;
       user-select: none;
 
-      &--missing {
-        background: $danger-bg;
-        color: $danger-fg;
-      }
-
       &-inner {
         display: flex;
         align-items: center;
         gap: 8px;
+        white-space: nowrap;
       }
 
       .DragHandle {
         color: lightgrey;
         cursor: grab;
         flex-shrink: 0;
-      }
-
-      .LangName {
-        margin-right: auto;
       }
 
       .Link {
@@ -1932,16 +1924,20 @@ $danger-fg: #c62828;
 
       .Inner {
         display: flex;
-        flex-direction: column;
-        gap: 6px;
+        flex-direction: row;
+        align-items: center;
+        gap: 8px;
 
         .Value {
           font-size: 13px;
           font-weight: 500;
           color: #333;
+          flex-shrink: 0;
+          text-align: right;
         }
 
         .Track {
+          flex: 1;
           height: 14px;
           background: #f0f0f0;
           border-radius: 2px;
@@ -1960,6 +1956,7 @@ $danger-fg: #c62828;
     display: inline-flex;
     align-items: center;
     gap: 6px;
+    white-space: nowrap;
     padding: 6px 12px;
     background: #e0f2f1;
     border: 1px solid #80cbc4;

--- a/app/frontend/utils/bubble-chart-permalink.ts
+++ b/app/frontend/utils/bubble-chart-permalink.ts
@@ -20,8 +20,8 @@ export interface ChartUiState {
   excludedOutliers: string[];
 }
 
-const CENTRALITY_MIN = 1;
-const CENTRALITY_MAX = 10;
+export const CENTRALITY_MIN = 1;
+export const CENTRALITY_MAX = 10;
 
 export const GRADE_KEYS = [
   "FA",

--- a/app/frontend/utils/language-order.ts
+++ b/app/frontend/utils/language-order.ts
@@ -1,0 +1,71 @@
+import { useSyncExternalStore } from "react";
+import type { TargetLanguage } from "./language-links";
+
+const LANG_ORDER_STORAGE_KEY = "articleLangColumnOrder";
+
+function reorder<T>(list: T[], from: number, to: number): T[] {
+  const next = [...list];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
+function loadStoredOrder(
+  defaults: readonly TargetLanguage[],
+): TargetLanguage[] {
+  try {
+    const raw = localStorage.getItem(LANG_ORDER_STORAGE_KEY);
+    if (!raw) return [...defaults];
+    const stored = JSON.parse(raw);
+    const sameSet =
+      Array.isArray(stored) &&
+      stored.length === defaults.length &&
+      defaults.every((l) => stored.includes(l));
+    return sameSet ? (stored as TargetLanguage[]) : [...defaults];
+  } catch {
+    return [...defaults];
+  }
+}
+
+function saveStoredOrder(order: TargetLanguage[]) {
+  try {
+    localStorage.setItem(LANG_ORDER_STORAGE_KEY, JSON.stringify(order));
+  } catch {
+    console.error("Failed to save language order to localStorage");
+  }
+}
+
+let currentOrder: TargetLanguage[] | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function setLanguageOrder(next: TargetLanguage[]) {
+  currentOrder = next;
+  saveStoredOrder(next);
+  listeners.forEach((listener) => listener());
+}
+
+function useLanguageOrder(
+  defaults: readonly TargetLanguage[],
+): [TargetLanguage[], (next: TargetLanguage[]) => void] {
+  if (currentOrder === null) {
+    currentOrder = loadStoredOrder(defaults);
+  }
+  const getSnapshot = () => currentOrder as TargetLanguage[];
+  const order = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return [order, setLanguageOrder];
+}
+
+export {
+  LANG_ORDER_STORAGE_KEY,
+  reorder,
+  loadStoredOrder,
+  saveStoredOrder,
+  useLanguageOrder,
+};


### PR DESCRIPTION
## Changes

**New features**

- Reorganized the chart filters into a basic/advanced layout
  - The basic controls (vertical axis, y-axis range, horizontal axis) stay visible, while the tag, centrality, quality assessment, and article protection filters now live in a collapsible "Advanced Filters" panel toggled from the tab bar
  - Tag, quality, and protection filters are now full-width rows with eye / eye-slash visibility toggles and highlighted "enabled" states, and the quality grades lay out across a grid
- Brought the same filter layout to the Languages tab
  - Both tabs now share the identical basic + advanced filter set, with the bubble-chart-only vertical axis and y-axis range controls hidden on the Languages tab
- Moved the chart legend into a modal
  - New "Legend" button (next to "Glossary") opens the legend in a popup, with the quality-assessment note kept as a footnote
- Added the ability to reorder languages in the Languages tab
  - Language column order is now configurable and reflected in both the languages grid and the per-article comparison modal
- Made "scaled" the default horizontal-axis mode
- Added pan locking so the chart only pans along the x-axis

**Refactoring**

- Extracted the filter controls into reusable components (`AxisControls` and `AdvancedFilterPanel`) shared by both tabs, so the two tabs stay in sync
- Centralized the centrality bounds in the permalink util

**Bug fixes**

- Fixed the centrality slider handles overlapping the language comparison modal (the modal was missing a z-index)
- Fixed the translate-article button clipping through the comparison modal's border
- Fixed chart gridlines not rendering fully                                                                                                                                                                       
- Fixed negative values sometimes showing up when setting a max y-value

**Videos/Screenshots**

language reordering

https://github.com/user-attachments/assets/997b1a35-31b8-4458-951b-1b1cdfb8f1b7

filter changes

https://github.com/user-attachments/assets/e95d237c-d12b-41fe-8d0b-684e5348fa1f

advanced filters expanded

<img width="1849" height="268" alt="image" src="https://github.com/user-attachments/assets/16c5985b-7e75-4b4b-be94-02c1957b872a" />



