### PR TITLE
Fix sync preview hiding Apply button for tag-only re-publishes

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -32,6 +32,11 @@ class ImportsController < ApplicationController
 
     if @existing_topic
       @diff = TopicBuilderSyncService.compute_diff(topic: @existing_topic, package: @package)
+      # The article diff is tag-blind; a v2 re-publish can carry tag-only
+      # changes (identical article bag). Surface that so the view still
+      # offers Apply when only the tag taxonomy would change.
+      @tags_will_sync = TopicBuilderTagIngestService.applicable?(@package)
+      @tag_count = Array(@package['tags']).size
       render :sync_preview
     else
       @first_articles = @package.fetch('articles', []).first(PREVIEW_ARTICLE_LIMIT)

--- a/app/views/imports/sync_preview.html.erb
+++ b/app/views/imports/sync_preview.html.erb
@@ -39,9 +39,14 @@
     <div><dt>Source topic:</dt> <dd><%= @package['source_topic'] %></dd></div>
   </dl>
 
-  <% if @diff.empty? %>
+  <% has_changes = !@diff.empty? || @tags_will_sync %>
+  <% unless has_changes %>
     <p class="nochange">No changes to apply — the package matches the current article bag.</p>
   <% else %>
+    <% if @diff.empty? %>
+      <p class="nochange">No article changes — the article bag already matches.
+      The tag taxonomy (<%= @tag_count %> tag<%= 's' if @tag_count != 1 %>) will be (re-)synced.</p>
+    <% else %>
     <div class="diff-summary">
       <strong>Summary:</strong>
       <ul>
@@ -108,6 +113,8 @@
           </tbody>
         </table>
       </div>
+    <% end %>
+
     <% end %>
 
     <%= form_with url: import_path(handle: @handle), method: :post, local: true, class: 'actions' do %>


### PR DESCRIPTION
TopicBuilderSyncService's Diff#empty? is computed from article adds/removes/centrality only — it's blind to tags. A v2 re-publish that changes only the tag taxonomy (identical article bag) rendered "No changes to apply" with no Apply button, so the tags could never be ingested through the UI, even though SyncTopicBuilderArticlesJob runs TopicBuilderTagIngestService#sync! unconditionally.

Expose @tags_will_sync (TopicBuilderTagIngestService.applicable?) and @tag_count from ImportsController#show, and render the Apply button when the article diff is non-empty OR tags will sync, with a tag-only note in the latter case.