### PR TITLE
Manual article removal, UI and chart improvements

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -4,7 +4,8 @@ class TopicsController < ApiController
   before_action :authenticate_topic_editor!,
                 only: %i[create update destroy import_users import_articles
                          generate_timepoints incremental_topic_build
-                         generate_article_analytics start_data_generation]
+                         generate_article_analytics start_data_generation
+                         remove_article]
 
   def index
     if current_editor && params[:owned]
@@ -146,6 +147,15 @@ class TopicsController < ApiController
   rescue ImpactVisualizerErrors::TopicNotReadyForDataGeneration
     render json: { error: 'Topic has no articles to process. Add articles or attach a CSV first.' },
            status: :unprocessable_entity
+  end
+
+  def remove_article
+    topic = find_editable_topic
+    removed = topic.remove_article_from_active_bag!(title: params[:title].to_s)
+    return render(json: { error: 'Article not found in topic' }, status: :not_found) unless removed
+
+    @topic = topic.reload
+    render :show
   end
 
   protected

--- a/app/frontend/components/article-detail-panel.component.tsx
+++ b/app/frontend/components/article-detail-panel.component.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { FaArrowRight } from "react-icons/fa6";
 import { FiExternalLink } from "react-icons/fi";
 import { IoClose } from "react-icons/io5";
+import { BsTrash } from "react-icons/bs";
 import Spinner from "./spinner.component";
 import type { ArticleAnalytics } from "../types/bubble-chart.type";
 import { getWikiUrl } from "../utils/search-utils";
@@ -33,10 +34,16 @@ function ArticleDetailPanel({
   article,
   wiki,
   onClose,
+  canEdit = false,
+  onRemove,
+  removing = false,
 }: {
   article: ArticleRow;
   wiki?: Wiki;
   onClose: () => void;
+  canEdit?: boolean;
+  onRemove?: (title: string) => void;
+  removing?: boolean;
 }) {
   const [activeTab, setActiveTab] = useState<"all" | "peacock">("all");
   const lang = wiki?.language ?? "en";
@@ -109,6 +116,18 @@ function ArticleDetailPanel({
               <FiExternalLink size={18} />
             </a>
           </h3>
+          {canEdit && onRemove && (
+            <button
+              type="button"
+              className="RemoveBtn"
+              onClick={() => onRemove(article.article)}
+              disabled={removing}
+              title="Remove this article from the topic"
+            >
+              <BsTrash size={14} aria-hidden="true" />
+              <span>Remove from topic</span>
+            </button>
+          )}
           <button className="Close" onClick={onClose} aria-label="Close">
             <IoClose size={28} />
           </button>

--- a/app/frontend/components/article-detail-panel.component.tsx
+++ b/app/frontend/components/article-detail-panel.component.tsx
@@ -10,7 +10,11 @@ import {
   fetchArticleWordFrequencies,
   PEACOCK_TERMS,
 } from "../utils/word-cloud-utils";
-import { fetchArticleNeeds } from "../utils/article-quality-utils";
+import {
+  fetchArticleNeeds,
+  MICROTASK_GENERATOR_NAME,
+  MICROTASK_GENERATOR_URL,
+} from "../utils/article-quality-utils";
 
 type Wiki = {
   language: string;
@@ -316,6 +320,19 @@ function ArticleDetailPanel({
                     </li>
                   ))}
                 </ul>
+              )}
+              {!loadingNeeds && isWikipedia && (
+                <div className="Credit">
+                  Suggestions based on the Wikimedia{" "}
+                  <a
+                    href={MICROTASK_GENERATOR_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {MICROTASK_GENERATOR_NAME}
+                  </a>{" "}
+                  tool.
+                </div>
               )}
             </div>
           </div>

--- a/app/frontend/components/bubble-cell.component.tsx
+++ b/app/frontend/components/bubble-cell.component.tsx
@@ -53,24 +53,24 @@ const BubbleCell: React.FC<BubbleCellProps> = ({
         <circle
           r={scales.talk(row.talk_size)}
           fill="none"
-          stroke="#2196f3"
+          stroke={row.talk_color ?? "#2196f3"}
           strokeWidth={1.5}
         />
         <circle
           r={scales.prevArticle(row.prev_article_size)}
           fill="none"
-          stroke="#64b5f6"
+          stroke={row.prev_article_color ?? "#64b5f6"}
           strokeWidth={1.5}
           strokeDasharray="4 4"
         />
         <circle
           r={scales.lead(row.lead_section_size)}
-          fill="#90caf9"
+          fill={row.lead_color ?? "#90caf9"}
           opacity={0.8}
         />
         <circle
           r={scales.article(row.article_size)}
-          fill="#0d47a1"
+          fill={row.assessment_grade_color ?? "#0d47a1"}
           opacity={0.5}
           stroke="white"
           strokeWidth={1}

--- a/app/frontend/components/filtered-articles-sidebar.component.tsx
+++ b/app/frontend/components/filtered-articles-sidebar.component.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react";
 import { List } from "react-window";
 import { GoTriangleLeft, GoTriangleRight } from "react-icons/go";
 import { FiExternalLink } from "react-icons/fi";
-import { BsEye, BsEyeSlash } from "react-icons/bs";
+import { BsEye, BsEyeSlash, BsTrash } from "react-icons/bs";
 import { getWikiUrl } from "../utils/search-utils";
 import type { ArticleRow } from "./article-detail-panel.component";
 
@@ -18,6 +18,9 @@ interface FilteredArticlesSidebarProps {
   excludedOutliers?: Set<string>;
   onToggleOutlier?: (article: string) => void;
   onClearOutliers?: () => void;
+  canEdit?: boolean;
+  onRemoveArticle?: (title: string) => void;
+  removing?: boolean;
 }
 
 interface SidebarRowProps {
@@ -26,11 +29,22 @@ interface SidebarRowProps {
   onArticleClick?: (article: ArticleRow) => void;
   excludedOutliers?: Set<string>;
   onToggleOutlier?: (article: string) => void;
+  canEdit?: boolean;
+  onRemoveArticle?: (title: string) => void;
+  removing?: boolean;
 }
 
 function SidebarRow(props: SidebarRowProps): React.ReactElement | null {
-  const { articles, wiki, onArticleClick, excludedOutliers, onToggleOutlier } =
-    props;
+  const {
+    articles,
+    wiki,
+    onArticleClick,
+    excludedOutliers,
+    onToggleOutlier,
+    canEdit,
+    onRemoveArticle,
+    removing,
+  } = props;
   const { index, style } = props as unknown as {
     index: number;
     style: React.CSSProperties;
@@ -76,6 +90,18 @@ function SidebarRow(props: SidebarRowProps): React.ReactElement | null {
       >
         <FiExternalLink />
       </a>
+      {canEdit && onRemoveArticle && (
+        <button
+          type="button"
+          className="RemoveBtn"
+          onClick={() => onRemoveArticle(articleRow.article)}
+          disabled={removing}
+          title="Remove from topic"
+          aria-label={`Remove ${articleRow.article} from topic`}
+        >
+          <BsTrash />
+        </button>
+      )}
     </li>
   );
 }
@@ -91,6 +117,9 @@ const FilteredArticlesSidebar: React.FC<FilteredArticlesSidebarProps> =
       excludedOutliers,
       onToggleOutlier,
       onClearOutliers,
+      canEdit,
+      onRemoveArticle,
+      removing,
     }) => {
       const [excludedOnly, setExcludedOnly] = useState<boolean>(false);
 
@@ -168,6 +197,9 @@ const FilteredArticlesSidebar: React.FC<FilteredArticlesSidebarProps> =
                   onArticleClick,
                   excludedOutliers,
                   onToggleOutlier,
+                  canEdit,
+                  onRemoveArticle,
+                  removing,
                 }}
                 overscanCount={10}
                 style={{ maxHeight: LIST_HEIGHT }}

--- a/app/frontend/components/glossary-modal.component.tsx
+++ b/app/frontend/components/glossary-modal.component.tsx
@@ -112,6 +112,15 @@ const GLOSSARY_SECTIONS: GlossarySection[] = [
     ],
   },
   {
+    title: "Tags",
+    terms: [
+      {
+        name: "Tag",
+        def: "A topic-specific label assigned to articles, used to filter the chart down to a subset of articles.",
+      },
+    ],
+  },
+  {
     title: "Page protections",
     intro:
       "Administrative controls applied to high-traffic or contentious pages.",

--- a/app/frontend/components/my-topic-index.component.tsx
+++ b/app/frontend/components/my-topic-index.component.tsx
@@ -27,14 +27,6 @@ function MyTopicIndex() {
   return (
     <section className="Section u-lg-pr05">
       <div className="Container Container--padded">
-        <div className="u-mb2">
-          <Link
-            className="Button"
-            to="/my-topics/new"
-          >
-            Create a New Topic
-          </Link>
-        </div>
         <div className="TopicIndex">
           {status === 'pending' && <Spinner />}
 

--- a/app/frontend/components/pagepile-tool.tsx
+++ b/app/frontend/components/pagepile-tool.tsx
@@ -3,6 +3,7 @@ import { PagePileResponse } from "../types/search-tool.type";
 import toast from "react-hot-toast";
 import LoadingOval from "./loading-oval.component";
 import ArticlesTable from "./articles-table.component";
+import ToolHowTo from "./tool-how-to.component";
 
 export default function PagePileTool() {
   const [pagePileID, setPagePileID] = useState<string>("");
@@ -43,11 +44,23 @@ export default function PagePileTool() {
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
       <p className="ToolIntro">
-        PagePile (pagepile.toolforge.org) is an external Wikimedia tool that
-        stores fixed lists of Wikipedia pages, each identified by a number. If
-        you have a PagePile ID, paste it here to import that exact list of
-        articles.
+        <a href="https://pagepile.toolforge.org" target="_blank" rel="noreferrer">PagePile</a>{" "}
+        is an external Wikimedia tool that stores fixed lists of Wikipedia pages,
+        each identified by a number. Import one of those saved lists using its
+        PagePile ID.
       </p>
+
+      <ToolHowTo
+        steps={[
+          "Find your list on pagepile.toolforge.org.",
+          "Copy its numeric PagePile ID.",
+          "Paste the ID and click Run Query.",
+        ]}
+        example={{
+          inputs: [{ label: "PagePile ID", value: "10000" }],
+          result: "the exact list of pages saved in that PagePile.",
+        }}
+      />
 
       <form onSubmit={handleSubmit}>
         <h3>Enter PagePile ID</h3>

--- a/app/frontend/components/pagepile-tool.tsx
+++ b/app/frontend/components/pagepile-tool.tsx
@@ -42,6 +42,12 @@ export default function PagePileTool() {
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
+      <p className="ToolIntro">
+        PagePile (pagepile.toolforge.org) is an external Wikimedia tool that
+        stores fixed lists of Wikipedia pages, each identified by a number. If
+        you have a PagePile ID, paste it here to import that exact list of
+        articles.
+      </p>
 
       <form onSubmit={handleSubmit}>
         <h3>Enter PagePile ID</h3>

--- a/app/frontend/components/petscan-tool.tsx
+++ b/app/frontend/components/petscan-tool.tsx
@@ -3,6 +3,7 @@ import { PetscanResponse } from "../types/search-tool.type";
 import toast from "react-hot-toast";
 import LoadingOval from "./loading-oval.component";
 import ArticlesTable from "./articles-table.component";
+import ToolHowTo from "./tool-how-to.component";
 
 export default function PetScanTool() {
   const [petscanID, setPetscanID] = useState<string>("");
@@ -49,11 +50,23 @@ export default function PetScanTool() {
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
       <p className="ToolIntro">
-        PetScan (petscan.wmcloud.org) is an external Wikimedia tool for building
-        article lists from categories, templates, and other criteria. If you've
-        already created a query there or have a query in mind to look at, paste
-        its PetScan ID to import the resulting articles.
+        <a href="https://petscan.wmcloud.org" target="_blank" rel="noreferrer">PetScan</a>{" "}
+        is an external Wikimedia tool for building article lists from categories,
+        templates, and other criteria. Import the results of a query you've built
+        there using its PetScan ID.
       </p>
+
+      <ToolHowTo
+        steps={[
+          "Build and run your query on petscan.wmcloud.org.",
+          "Copy the PSID (PetScan ID) shown in the results / URL.",
+          "Paste the ID and click Run Query.",
+        ]}
+        example={{
+          inputs: [{ label: "PetScan ID", value: "100" }],
+          result: "the articles produced by that PetScan query.",
+        }}
+      />
 
       <form onSubmit={handleSubmit}>
         <h3>Enter PetScan ID</h3>

--- a/app/frontend/components/petscan-tool.tsx
+++ b/app/frontend/components/petscan-tool.tsx
@@ -48,6 +48,12 @@ export default function PetScanTool() {
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
+      <p className="ToolIntro">
+        PetScan (petscan.wmcloud.org) is an external Wikimedia tool for building
+        article lists from categories, templates, and other criteria. If you've
+        already created a query there or have a query in mind to look at, paste
+        its PetScan ID to import the resulting articles.
+      </p>
 
       <form onSubmit={handleSubmit}>
         <h3>Enter PetScan ID</h3>

--- a/app/frontend/components/query-builder.component.tsx
+++ b/app/frontend/components/query-builder.component.tsx
@@ -11,6 +11,7 @@ import LoadingOval from "./loading-oval.component";
 import React from "react";
 import toast from "react-hot-toast";
 import { v4 as uuidv4 } from "uuid";
+import ToolHowTo from "./tool-how-to.component";
 
 export default function QueryBuilder() {
   const [queryItemsData, setQueryItemsData] = useState<QueryProperty[]>([
@@ -50,7 +51,7 @@ export default function QueryBuilder() {
   const handleRemoveQueryItem = (indexToRemove: number) => {
     if (queryItemsData.length > 1) {
       const updatedProperties = queryItemsData.filter(
-        (_, idx) => idx !== indexToRemove
+        (_, idx) => idx !== indexToRemove,
       );
       setQueryItemsData(updatedProperties);
     }
@@ -85,10 +86,10 @@ export default function QueryBuilder() {
 
     const gender = queryItemsData.filter((item) => item.property === "gender");
     const ethnicity = queryItemsData.filter(
-      (item) => item.property === "ethnicity"
+      (item) => item.property === "ethnicity",
     );
     const occupations = queryItemsData.filter(
-      (item) => item.property === "occupation"
+      (item) => item.property === "occupation",
     );
 
     const query: string = buildWikidataQuery(
@@ -96,7 +97,7 @@ export default function QueryBuilder() {
       gender.length > 0 ? gender[0].qValue.id : "",
       ethnicity.length > 0 ? ethnicity[0].qValue.id : "",
       languageCode,
-      { requireWikipediaArticle: requireWikiArticle }
+      { requireWikipediaArticle: requireWikiArticle },
     );
     try {
       const response = await fetch(
@@ -105,7 +106,7 @@ export default function QueryBuilder() {
           headers: {
             Accept: "application/sparql-results+json",
           },
-        }
+        },
       );
 
       if (!response.ok) {
@@ -135,13 +136,30 @@ export default function QueryBuilder() {
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
       <p className="ToolIntro">
-        Wikidata is the structured database of facts behind Wikipedia. This tool
-        builds a list of articles that share characteristics you choose (such as
+        <a href="https://www.wikidata.org" target="_blank" rel="noreferrer">
+          Wikidata
+        </a>{" "}
+        is the structured database of facts behind Wikipedia. This tool builds a
+        list of articles that share characteristics you choose (such as
         occupation, gender, or country of citizenship) in the language you pick.
-        Enter a two-letter language code (for example, en for English or fr for
-        French) to set the Wikipedia language, add one or more properties, then
-        run the query to get the matching articles.
       </p>
+
+      <ToolHowTo
+        steps={[
+          "Enter a two-letter language code (e.g. en) to choose the Wikipedia language.",
+          "Add one or more properties (occupation, gender, or ethnicity) and pick a value for each. Combining properties narrows the results and keeps the query fast.",
+          'Optionally tick "Require Wiki Article" to keep only items that have an article in that language.',
+          "Click Run Query to get the matching articles.",
+        ]}
+        example={{
+          inputs: [
+            { label: "Language code", value: "en" },
+            { label: "Occupation", value: "astronaut" },
+            { label: "Gender", value: "female" },
+          ],
+          result: "English Wikipedia articles about women astronauts.",
+        }}
+      />
 
       <form onSubmit={(e) => handleSubmit(e)}>
         <h3>Enter Language Code</h3>

--- a/app/frontend/components/query-builder.component.tsx
+++ b/app/frontend/components/query-builder.component.tsx
@@ -134,6 +134,14 @@ export default function QueryBuilder() {
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
+      <p className="ToolIntro">
+        Wikidata is the structured database of facts behind Wikipedia. This tool
+        builds a list of articles that share characteristics you choose (such as
+        occupation, gender, or country of citizenship) in the language you pick.
+        Enter a two-letter language code (for example, en for English or fr for
+        French) to set the Wikipedia language, add one or more properties, then
+        run the query to get the matching articles.
+      </p>
 
       <form onSubmit={(e) => handleSubmit(e)}>
         <h3>Enter Language Code</h3>

--- a/app/frontend/components/root.component.tsx
+++ b/app/frontend/components/root.component.tsx
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import React from "react";
 import { Link, Outlet, ScrollRestoration } from "react-router-dom";
-import { MdOutlineArrowDropDown } from "react-icons/md";
+import { MdOutlineArrowDropDown, MdFeedback } from "react-icons/md";
 
 import UserStatus from "./user-status.component";
 
@@ -74,7 +74,11 @@ function Root() {
                 </div>
                 <div className="dropdown-content">
                   {SEARCH_TOOLS.map((tool) => (
-                    <Link key={tool.path} to={tool.path} className="Dropdown-tool">
+                    <Link
+                      key={tool.path}
+                      to={tool.path}
+                      className="Dropdown-tool"
+                    >
                       <span className="Dropdown-toolName">{tool.label}</span>
                       <span className="Dropdown-toolDesc">{tool.short}</span>
                     </Link>
@@ -85,6 +89,15 @@ function Root() {
           </div>
 
           <div className="Header-right">
+            <a
+              className="Button Button--feedback u-mr1"
+              href="https://meta.wikimedia.org/wiki/Talk:Visual_Analytics_for_Sustainability_and_Climate_Change/Tool?action=edit&section=new"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Give Feedback
+              <MdFeedback className="Button-icon" />
+            </a>
             <UserStatus />
           </div>
         </div>

--- a/app/frontend/components/root.component.tsx
+++ b/app/frontend/components/root.component.tsx
@@ -89,8 +89,10 @@ function Root() {
           </div>
 
           <div className="Header-right">
+            <UserStatus />
+            <span className="Header-divider" aria-hidden="true" />
             <a
-              className="Button Button--feedback u-mr1"
+              className="Button Button--feedback"
               href="https://meta.wikimedia.org/wiki/Talk:Visual_Analytics_for_Sustainability_and_Climate_Change/Tool?action=edit&section=new"
               target="_blank"
               rel="noopener noreferrer"
@@ -98,7 +100,6 @@ function Root() {
               Give Feedback
               <MdFeedback className="Button-icon" />
             </a>
-            <UserStatus />
           </div>
         </div>
       </header>

--- a/app/frontend/components/root.component.tsx
+++ b/app/frontend/components/root.component.tsx
@@ -5,6 +5,50 @@ import { MdOutlineArrowDropDown } from "react-icons/md";
 
 import UserStatus from "./user-status.component";
 
+const SEARCH_TOOLS = [
+  {
+    path: "/search/wikidata-tool",
+    label: "Wikidata Tool",
+    short:
+      "Find articles by their characteristics, such as people of a given occupation, gender, or nationality, using Wikidata.",
+  },
+  {
+    path: "/search/wikipedia-category-tool",
+    label: "Wikipedia Category Tool",
+    short:
+      "Collect articles by browsing a Wikipedia category and its subcategories.",
+  },
+  {
+    path: "/search/wiki-dashboard-course-tool",
+    label: "Education Dashboard Course Tool",
+    short:
+      "Import the articles edited in a Wiki Education / Programs & Events Dashboard course.",
+  },
+  {
+    path: "/search/wiki-dashboard-user-tool",
+    label: "Education Dashboard User Tool",
+    short:
+      "Import the articles a single editor worked on, from their Dashboard profile.",
+  },
+  {
+    path: "/search/petscan-tool",
+    label: "Petscan Tool",
+    short:
+      "Import a ready-made list of articles from PetScan using its query ID.",
+  },
+  {
+    path: "/search/pagepile-tool",
+    label: "Pagepile Tool",
+    short: "Import a saved list of pages from PagePile using its ID.",
+  },
+  {
+    path: "/search/user-set-tool",
+    label: "User Set Tool",
+    short:
+      "Get the articles edited by a predefined group of Wiki Education participants.",
+  },
+];
+
 function Root() {
   return (
     <>
@@ -29,19 +73,12 @@ function Root() {
                   Tools <MdOutlineArrowDropDown />
                 </div>
                 <div className="dropdown-content">
-                  <Link to="/search/wikidata-tool">Wikidata Tool</Link>
-                  <Link to="/search/wikipedia-category-tool">
-                    Wikipedia Category Tool
-                  </Link>
-                  <Link to="/search/wiki-dashboard-course-tool">
-                    Education Dashboard Course Tool
-                  </Link>
-                  <Link to="/search/wiki-dashboard-user-tool">
-                    Education Dashboard User Tool
-                  </Link>
-                  <Link to="/search/petscan-tool">Petscan Tool</Link>
-                  <Link to="/search/pagepile-tool">Pagepile Tool</Link>
-                  <Link to="/search/user-set-tool">User Set Tool</Link>
+                  {SEARCH_TOOLS.map((tool) => (
+                    <Link key={tool.path} to={tool.path} className="Dropdown-tool">
+                      <span className="Dropdown-toolName">{tool.label}</span>
+                      <span className="Dropdown-toolDesc">{tool.short}</span>
+                    </Link>
+                  ))}
                 </div>
               </div>
             </div>

--- a/app/frontend/components/tool-how-to.component.tsx
+++ b/app/frontend/components/tool-how-to.component.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+interface ToolHowToExample {
+  inputs: { label: string; value: string }[];
+  result: string;
+}
+
+interface ToolHowToProps {
+  steps: React.ReactNode[];
+  example?: ToolHowToExample;
+}
+
+export default function ToolHowTo({ steps, example }: ToolHowToProps) {
+  return (
+    <details className="ToolHowTo" open>
+      <summary>How to use</summary>
+      <ol>
+        {steps.map((step, index) => (
+          <li key={index}>{step}</li>
+        ))}
+      </ol>
+      {example && (
+        <div className="ToolHowTo-example">
+          <strong>Example</strong>
+          <ul className="ToolHowTo-exampleInputs">
+            {example.inputs.map((input, index) => (
+              <li key={index}>
+                {input.label}: <code>{input.value}</code>
+              </li>
+            ))}
+          </ul>
+          <span className="ToolHowTo-exampleResult">
+            Returns {example.result}
+          </span>
+        </div>
+      )}
+    </details>
+  );
+}

--- a/app/frontend/components/topic-detail.component.tsx
+++ b/app/frontend/components/topic-detail.component.tsx
@@ -34,8 +34,8 @@ function renderLoading() {
 function renderIntro({ topic, editorLabel }) {
   return (
     <div className="TopicDetailIntro u-mb2">
-      <div className="u-limitWidth50">
-        <h1 className="u-mt1 u-h1">{topic.name}</h1>
+      <div className="u-limitWidth50 TopicDetailIntro-main">
+        <h1 className="u-h1">{topic.name}</h1>
 
         <h3 className="u-mb05">
           Focus Period: {moment(topic.start_date).format("MMMM YYYY")} –{" "}
@@ -233,6 +233,15 @@ function TopicDetail() {
             {!topic.owned && <Link to="/">← Back to all Topics</Link>}
 
             {topic.owned && <Link to="/my-topics">← Back to My Topics</Link>}
+
+            {topic.owned && (
+              <Link
+                to={`/my-topics/edit/${topic.id}`}
+                className="Button Button--outlined"
+              >
+                Edit topic
+              </Link>
+            )}
           </div>
 
           {renderIntro({ topic, editorLabel })}

--- a/app/frontend/components/topic-detail.component.tsx
+++ b/app/frontend/components/topic-detail.component.tsx
@@ -296,6 +296,8 @@ function TopicDetail() {
             topicName={topic.name}
             topicStartDate={topic.start_date}
             topicEndDate={topic.end_date}
+            canEdit={topic.owned}
+            isTopicBuilderTopic={!!topic.tb_handle}
           />
         </div>
       )}
@@ -310,6 +312,8 @@ function TopicDetail() {
             topicName={topic.name}
             topicStartDate={topic.start_date}
             topicEndDate={topic.end_date}
+            canEdit={topic.owned}
+            isTopicBuilderTopic={!!topic.tb_handle}
           />
         </div>
       )}

--- a/app/frontend/components/topic-generation-progress.component.tsx
+++ b/app/frontend/components/topic-generation-progress.component.tsx
@@ -56,16 +56,16 @@ const PHASE_WEIGHTS = PHASE_BAR_COUNTS.map((n) => n / N_BARS);
 // "articles per timepoint" distribution rather than a uniform ramp.
 const BAR_HEIGHTS = [
   // import (3) — small, gently rising
-  0.25, 0.30, 0.32,
+  0.25, 0.3, 0.32,
   // analytics (12) — rising in clusters with occasional dips
-  0.42, 0.45, 0.40, 0.52, 0.58, 0.55, 0.65, 0.62, 0.70, 0.78, 0.85, 0.82,
+  0.42, 0.45, 0.4, 0.52, 0.58, 0.55, 0.65, 0.62, 0.7, 0.78, 0.85, 0.82,
   // timeline (15)
   // 15–17: late rise into peak
-  0.88, 0.95, 0.90,
+  0.88, 0.95, 0.9,
   // 18–22: plateau around the ~60% mark
   0.93, 0.92, 0.86, 0.94, 0.88,
   // 23–29: gentle decline with one bump (the "final ~40%")
-  0.84, 0.80, 0.82, 0.74, 0.68, 0.62, 0.55,
+  0.84, 0.8, 0.82, 0.74, 0.68, 0.62, 0.55,
 ];
 
 function phaseIdxForBar(i: number): number {
@@ -85,7 +85,10 @@ function isFailed(status: string | null | undefined) {
   return status === "failed" || status === "interrupted";
 }
 
-function derive(jobStatus: string | null | undefined, dataExists: boolean): PhaseStatus {
+function derive(
+  jobStatus: string | null | undefined,
+  dataExists: boolean,
+): PhaseStatus {
   if (isRunning(jobStatus)) return "running";
   if (isFailed(jobStatus)) return "error";
   return dataExists ? "complete" : "pending";
@@ -117,22 +120,25 @@ function buildImportPhase(topic: Topic): Phase {
   if (status === "running") {
     if (hasUsersCsv) {
       percent = Math.round((articlesPct + usersPct) / 2);
-      startedAt = _.min(
-        [topic.articles_import_started_at, topic.users_import_started_at].filter(
-          (v) => v != null,
-        ) as number[],
-      ) ?? null;
+      startedAt =
+        _.min(
+          [
+            topic.articles_import_started_at,
+            topic.users_import_started_at,
+          ].filter((v) => v != null) as number[],
+        ) ?? null;
     } else {
       percent = articlesPct;
       startedAt = topic.articles_import_started_at;
     }
   }
 
-  const detail = status === "running"
-    ? hasUsersCsv
-      ? `Importing — articles ${articlesPct}% · users ${usersPct}%`
-      : `Importing articles · ${articlesPct}%`
-    : null;
+  const detail =
+    status === "running"
+      ? hasUsersCsv
+        ? `Importing — articles ${articlesPct}% · users ${usersPct}%`
+        : `Importing articles · ${articlesPct}%`
+      : null;
 
   let countLabel: string | null = null;
   if (status === "complete") {
@@ -180,15 +186,22 @@ function buildAnalyticsPhase(topic: Topic): Phase {
     key: "analytics",
     label: "Analytics",
     status,
-    percent: status === "running" ? topic.generate_article_analytics_percent_complete : null,
-    startedAt: status === "running" ? topic.generate_article_analytics_started_at : null,
+    percent:
+      status === "running"
+        ? topic.generate_article_analytics_percent_complete
+        : null,
+    startedAt:
+      status === "running" ? topic.generate_article_analytics_started_at : null,
     detail,
     countLabel: null,
   };
 }
 
 function buildTimepointsPhase(topic: Topic): Phase {
-  const status = derive(topic.incremental_topic_build_status, !!topic.has_stats);
+  const status = derive(
+    topic.incremental_topic_build_status,
+    !!topic.has_stats,
+  );
 
   const currentStageKey = topic.incremental_topic_build_stage;
   const currentIdx = currentStageKey
@@ -205,16 +218,19 @@ function buildTimepointsPhase(topic: Topic): Phase {
     return { ...stage, state: "pending" as const };
   });
 
-  const detail = status === "running"
-    ? buildTimepointsDetail(topic, currentStageKey)
-    : null;
+  const detail =
+    status === "running" ? buildTimepointsDetail(topic, currentStageKey) : null;
 
   return {
     key: "timepoints",
     label: "Timeline",
     status,
-    percent: status === "running" ? topic.incremental_topic_build_percent_complete : null,
-    startedAt: status === "running" ? topic.incremental_topic_build_started_at : null,
+    percent:
+      status === "running"
+        ? topic.incremental_topic_build_percent_complete
+        : null,
+    startedAt:
+      status === "running" ? topic.incremental_topic_build_started_at : null,
     detail,
     countLabel: null,
     subStages,
@@ -357,7 +373,13 @@ function ProgressChart({
       preserveAspectRatio="none"
       aria-label={`Progress: ${Math.round(overallPercent)}%`}
     >
-      <line x1="0" y1="59" x2="300" y2="59" className="ProgressChart-baseline" />
+      <line
+        x1="0"
+        y1="59"
+        x2="300"
+        y2="59"
+        className="ProgressChart-baseline"
+      />
 
       {BAR_HEIGHTS.map((target, i) => {
         const phaseIdx = phaseIdxForBar(i);
@@ -410,9 +432,15 @@ function PhaseLegend({ phases }: { phases: Phase[] }) {
           )}
         >
           <span className="ProgressLegend-marker">
-            {phase.status === "complete" && <span className="ProgressLegend-check">✓</span>}
-            {phase.status === "running" && <span className="ProgressLegend-dot" />}
-            {phase.status === "pending" && <span className="ProgressLegend-dotPending" />}
+            {phase.status === "complete" && (
+              <span className="ProgressLegend-check">✓</span>
+            )}
+            {phase.status === "running" && (
+              <span className="ProgressLegend-dot" />
+            )}
+            {phase.status === "pending" && (
+              <span className="ProgressLegend-dotPending" />
+            )}
             {phase.status === "error" && "!"}
           </span>
           <span className="ProgressLegend-label">{phase.label}</span>
@@ -437,7 +465,8 @@ function OverflowMenu({
   useEffect(() => {
     if (!open) return;
     function onClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     }
     document.addEventListener("mousedown", onClick);
     return () => document.removeEventListener("mousedown", onClick);
@@ -486,7 +515,8 @@ function TopicGenerationProgress({ topic }: { topic: Topic }) {
 
   const phases = buildPhases(topic);
   const state = topic.data_generation_state || "idle";
-  const overallPercent = state === "complete" ? 100 : computeOverallPercent(phases);
+  const overallPercent =
+    state === "complete" ? 100 : computeOverallPercent(phases);
 
   const currentPhase = phases.find((p) => p.status === "running") || null;
   const currentEta = currentPhase
@@ -509,10 +539,22 @@ function TopicGenerationProgress({ topic }: { topic: Topic }) {
         <h4 className="TopicProgress-title">
           {state === "idle" && "Data generation"}
           {state === "running" && "Generating data"}
-          {state === "complete" && "Data is up to date"}
+          {state === "complete" && "Last updated:"}
+          {state === "complete" && topic.data_updated_at && (
+            <span className="TopicProgress-updatedAt">
+              {" "}
+              {new Date(topic.data_updated_at).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </span>
+          )}
         </h4>
         {state === "running" && currentEta != null && (
-          <span className="TopicProgress-eta">{formatEta(currentEta)} left</span>
+          <span className="TopicProgress-eta">
+            {formatEta(currentEta)} left
+          </span>
         )}
         {canEdit && state !== "idle" && (
           <OverflowMenu

--- a/app/frontend/components/topic-generation-progress.component.tsx
+++ b/app/frontend/components/topic-generation-progress.component.tsx
@@ -2,7 +2,6 @@
 import _ from "lodash";
 import React, { useState, useEffect, useRef } from "react";
 import cn from "classnames";
-import { Link } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 // Types
@@ -467,13 +466,6 @@ function OverflowMenu({
           >
             Restart data generation
           </button>
-          <Link
-            to={`/my-topics/edit/${topic.id}`}
-            className="TopicOverflow-item"
-            onClick={() => setOpen(false)}
-          >
-            Edit topic
-          </Link>
         </div>
       )}
     </div>
@@ -572,12 +564,6 @@ function TopicGenerationProgress({ topic }: { topic: Topic }) {
           {cannotStartReason ||
             "Add articles to this topic before generating data."}
         </div>
-      )}
-
-      {canEdit && state === "idle" && (
-        <Link to={`/my-topics/edit/${topic.id}`} className="TopicProgress-editLink">
-          Edit topic
-        </Link>
       )}
 
       {canEdit && (

--- a/app/frontend/components/user-set-tool.tsx
+++ b/app/frontend/components/user-set-tool.tsx
@@ -4,6 +4,7 @@ import toast from "react-hot-toast";
 import { UserSetResponse } from "../types/search-tool.type";
 import LoadingOval from "./loading-oval.component";
 import ArticlesTable from "./articles-table.component";
+import ToolHowTo from "./tool-how-to.component";
 
 const userSetOptions = [
   { value: "", label: "-- Choose an option --" },
@@ -80,11 +81,26 @@ export default function UserSetTool() {
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
       <p className="ToolIntro">
-        Import articles edited by a specific Wiki Education community, for
-        example the Wikipedia Student Program or the Scholars &amp; Scientists
-        program. Choose the group and whether to include students only, or
-        students and instructors.
+        Import articles edited by a specific{" "}
+        <a href="https://wikiedu.org" target="_blank" rel="noreferrer">Wiki Education</a>{" "}
+        community, for example the Wikipedia Student Program or the Scholars
+        &amp; Scientists program.
       </p>
+
+      <ToolHowTo
+        steps={[
+          "Select a user group (e.g. Wikipedia Student Program).",
+          "Select a user type — students only, or students and instructors.",
+          "Click Run Query.",
+        ]}
+        example={{
+          inputs: [
+            { label: "User group", value: "Scholars & Scientists" },
+            { label: "User type", value: "Students and Instructors" },
+          ],
+          result: "the articles edited by that group.",
+        }}
+      />
 
       <form onSubmit={handleSubmit}>
         <label>

--- a/app/frontend/components/user-set-tool.tsx
+++ b/app/frontend/components/user-set-tool.tsx
@@ -79,6 +79,12 @@ export default function UserSetTool() {
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
+      <p className="ToolIntro">
+        Import articles edited by a specific Wiki Education community, for
+        example the Wikipedia Student Program or the Scholars &amp; Scientists
+        program. Choose the group and whether to include students only, or
+        students and instructors.
+      </p>
 
       <form onSubmit={handleSubmit}>
         <label>

--- a/app/frontend/components/user-status.component.tsx
+++ b/app/frontend/components/user-status.component.tsx
@@ -20,6 +20,9 @@ function UserStatus() {
 
       {signedIn && (
         <div className="Header-userInfo">
+          <Link className="Button u-mr1" to="/my-topics/new">
+            Create a New Topic
+          </Link>
           <Link className="Button u-mr1" to="/my-topics">
             {isAdmin ? "Manage All Topics" : "Manage Your Topics"}
           </Link>

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -7,8 +7,9 @@ import React, {
   useDeferredValue,
 } from "react";
 import vegaEmbed, { VisualizationSpec, EmbedOptions, Result } from "vega-embed";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
+import toast from "react-hot-toast";
 import {
   BsBook,
   BsInfoCircle,
@@ -44,6 +45,7 @@ import {
   formatProtectionSummary,
   xAxisTitleForKey,
 } from "../utils/bubble-chart-utils";
+import TopicService from "../services/topic.service";
 import { fetchLanguageLinks, TARGET_LANGUAGES } from "../utils/language-links";
 import type { LangLinksProgress } from "../utils/language-links";
 import { exportChartImage } from "../utils/chart-image-export";
@@ -69,6 +71,8 @@ interface WikiBubbleChartProps {
   topicName?: string;
   topicStartDate?: string;
   topicEndDate?: string;
+  canEdit?: boolean;
+  isTopicBuilderTopic?: boolean;
 }
 
 const HEIGHT = 650;
@@ -155,12 +159,15 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   topicName,
   topicStartDate,
   topicEndDate,
+  canEdit = false,
+  isTopicBuilderTopic = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<Result | null>(null);
   const sortedRowsRef = useRef<any[]>([]);
   const lastEmbeddedSortedRowsRef = useRef<any[] | null>(null);
   const [searchParams] = useSearchParams();
+  const queryClient = useQueryClient();
 
   // Parse the shared view from the URL exactly once, so every control below can
   // initialize straight from it without a URL->state effect (which would loop).
@@ -1243,6 +1250,39 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     setShowLabels(checked);
   };
 
+  const removeArticleMutation = useMutation({
+    mutationFn: (title: string) => TopicService.removeArticle(topicId!, title),
+    onSuccess: (updatedTopic, title) => {
+      queryClient.invalidateQueries({
+        queryKey: ["articleAnalytics", String(topicId)],
+      });
+      queryClient.setQueryData(["topic", String(topicId)], updatedTopic);
+      setSelectedArticle((cur) => (cur?.article === title ? null : cur));
+      setExcludedOutliers((prev) => {
+        if (!prev.has(title)) return prev;
+        const next = new Set(prev);
+        next.delete(title);
+        return next;
+      });
+      toast.success(`Removed "${title}" from this topic`);
+    },
+    onError: () => toast.error("Failed to remove article"),
+  });
+
+  const handleRemoveArticle = (title: string) => {
+    if (!canEdit || !topicId) return;
+    const tbNote = isTopicBuilderTopic
+      ? "\n\nNote: this topic syncs from Topic Builder, so a future sync may re-add this article."
+      : "";
+    if (
+      window.confirm(
+        `Remove "${title}" from this topic? This deletes its analytics and cannot be undone.${tbNote}`,
+      )
+    ) {
+      removeArticleMutation.mutate(title);
+    }
+  };
+
   const handleToggleOutlier = (article: string) => {
     setExcludedOutliers((prev) => {
       const next = new Set(prev);
@@ -1483,6 +1523,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             excludedOutliers={excludedOutliers}
             onToggleOutlier={handleToggleOutlier}
             onClearOutliers={handleClearOutliers}
+            canEdit={canEdit && !!topicId}
+            onRemoveArticle={handleRemoveArticle}
+            removing={removeArticleMutation.isPending}
           />
         </div>
 
@@ -1583,6 +1626,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           article={selectedArticle}
           wiki={wiki}
           onClose={() => setSelectedArticle(null)}
+          canEdit={canEdit && !!topicId}
+          onRemove={handleRemoveArticle}
+          removing={removeArticleMutation.isPending}
         />
       )}
 

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -38,7 +38,7 @@ import type {
 import {
   convertAnalyticsToCSV,
   convertAnalyticsToWikitext,
-  getAssessmentColor,
+  getAssessmentPalette,
   compareArticlesByPublicationDateAsc,
   compareArticlesByNumericFieldAsc,
   formatProtectionSummary,
@@ -286,14 +286,16 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         const protections = analytics?.article_protections ?? [];
         const hasMoveRestriction = protections.some((p) => p.type === "move");
         const hasEditRestriction = protections.some((p) => p.type === "edit");
+        const palette = getAssessmentPalette(analytics?.assessment_grade);
 
         return {
           article,
           ...analytics,
           classifications: analytics?.classifications ?? [],
-          assessment_grade_color: getAssessmentColor(
-            analytics?.assessment_grade,
-          ),
+          assessment_grade_color: palette.article,
+          talk_color: palette.talk,
+          prev_article_color: palette.prevArticle,
+          lead_color: palette.lead,
           protection_summary: formatProtectionSummary(protections),
           has_move_restriction: hasMoveRestriction,
           has_edit_restriction: hasEditRestriction,
@@ -816,7 +818,6 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
           mark: {
             type: "circle",
             fill: null,
-            stroke: "#2196f3",
             strokeWidth: 1.5,
             cursor: "pointer",
           },
@@ -827,6 +828,12 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               type: "quantitative",
               scale: { type: "sqrt", range: [50, 1500] },
             },
+            stroke: {
+              field: "talk_color",
+              type: "nominal",
+              scale: null,
+              legend: null,
+            },
             opacity: makeOpacityEncoding(1),
           },
         },
@@ -836,7 +843,6 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
             type: "circle",
             fill: null,
             strokeDash: [4, 4],
-            stroke: "#64b5f6",
             strokeWidth: 1.5,
             cursor: "pointer",
           },
@@ -847,6 +853,12 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               type: "quantitative",
               scale: { type: "sqrt", range: [20, 600] },
             },
+            stroke: {
+              field: "prev_article_color",
+              type: "nominal",
+              scale: null,
+              legend: null,
+            },
             opacity: makeOpacityEncoding(1),
           },
         },
@@ -854,7 +866,6 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         {
           mark: {
             type: "circle",
-            fill: "#90caf9",
             opacity: 0.8,
             cursor: "pointer",
           },
@@ -865,14 +876,19 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               type: "quantitative",
               scale: { type: "sqrt", range: [30, 800] },
             },
+            fill: {
+              field: "lead_color",
+              type: "nominal",
+              scale: null,
+              legend: null,
+            },
             opacity: makeOpacityEncoding(0.8),
           },
         },
-        // Article size circle (article_size)
+        // Article size circle (article_size), colored by quality assessment
         {
           mark: {
             type: "circle",
-            fill: "#0d47a1",
             opacity: 0.5,
             stroke: "white",
             strokeWidth: 1,
@@ -918,6 +934,12 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               field: "article_size",
               type: "quantitative",
               scale: { type: "sqrt", range: [20, 600] },
+            },
+            fill: {
+              field: "assessment_grade_color",
+              type: "nominal",
+              scale: null,
+              legend: null,
             },
             opacity: makeOpacityEncoding(0.5),
           },

--- a/app/frontend/components/wiki-dashboard-tool.component.tsx
+++ b/app/frontend/components/wiki-dashboard-tool.component.tsx
@@ -93,6 +93,12 @@ export default function WikiDashboardCourseTool() {
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
+      <p className="ToolIntro">
+        The Programs &amp; Events Dashboard (and the Wiki Education Dashboard)
+        tracks the editing done in Wikipedia courses and edit-a-thons. Paste a
+        course's URL to import the list of articles its participants created or
+        edited.
+      </p>
 
       <form onSubmit={handleSubmit}>
         <h3>Enter Course URL</h3>

--- a/app/frontend/components/wiki-dashboard-tool.component.tsx
+++ b/app/frontend/components/wiki-dashboard-tool.component.tsx
@@ -9,6 +9,7 @@ import {
 } from "../types/search-tool.type";
 import { extractDashboardURLInfo } from "../utils/search-utils";
 import ArticlesTable from "./articles-table.component";
+import ToolHowTo from "./tool-how-to.component";
 
 export default function WikiDashboardCourseTool() {
   const [courseURL, setCourseURL] = useState("");
@@ -94,11 +95,35 @@ export default function WikiDashboardCourseTool() {
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
       <p className="ToolIntro">
-        The Programs &amp; Events Dashboard (and the Wiki Education Dashboard)
-        tracks the editing done in Wikipedia courses and edit-a-thons. Paste a
-        course's URL to import the list of articles its participants created or
-        edited.
+        The{" "}
+        <a href="https://outreachdashboard.wmflabs.org" target="_blank" rel="noreferrer">
+          Programs &amp; Events Dashboard
+        </a>{" "}
+        (and the{" "}
+        <a href="https://dashboard.wikiedu.org" target="_blank" rel="noreferrer">
+          Wiki Education Dashboard
+        </a>
+        ) tracks the editing done in Wikipedia courses and edit-a-thons. Use it
+        to import the articles a course's participants created or edited.
       </p>
+
+      <ToolHowTo
+        steps={[
+          "Open the course on the Dashboard and copy its URL from your browser.",
+          "Paste the course URL into the field.",
+          "Click Run Query to import the articles its participants created or edited.",
+        ]}
+        example={{
+          inputs: [
+            {
+              label: "Course URL",
+              value:
+                "https://dashboard.wikiedu.org/courses/University_of_Oklahoma/Cold_War_Science_(Spring_2022)",
+            },
+          ],
+          result: "the articles that course's participants created or edited.",
+        }}
+      />
 
       <form onSubmit={handleSubmit}>
         <h3>Enter Course URL</h3>

--- a/app/frontend/components/wiki-dashboard-user-tool.component.tsx
+++ b/app/frontend/components/wiki-dashboard-user-tool.component.tsx
@@ -84,6 +84,11 @@ export default function WikiDashboardUserTool() {
   return (
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
+      <p className="ToolIntro">
+        Look up an individual editor on the Wiki Education or Outreach Dashboard
+        and import the articles they created or edited. Enter their username (or
+        profile URL) and choose which dashboard to search.
+      </p>
 
       <form onSubmit={handleSubmit}>
         <h3>Enter Username or Profile URL</h3>

--- a/app/frontend/components/wiki-dashboard-user-tool.component.tsx
+++ b/app/frontend/components/wiki-dashboard-user-tool.component.tsx
@@ -5,6 +5,7 @@ import LoadingOval from "./loading-oval.component";
 import ArticlesTable from "./articles-table.component";
 import { extractDashboardUsername } from "../utils/search-utils";
 import { DashboardUserToolResponse } from "../types/search-tool.type";
+import ToolHowTo from "./tool-how-to.component";
 
 export default function WikiDashboardUserTool() {
   const [userInputString, setUserInputString] = useState<string>("");
@@ -85,10 +86,31 @@ export default function WikiDashboardUserTool() {
     <div className="Container Container--padded">
       <h1>Impact Search</h1>
       <p className="ToolIntro">
-        Look up an individual editor on the Wiki Education or Outreach Dashboard
-        and import the articles they created or edited. Enter their username (or
-        profile URL) and choose which dashboard to search.
+        Look up an individual editor on the{" "}
+        <a href="https://dashboard.wikiedu.org" target="_blank" rel="noreferrer">
+          Wiki Education Dashboard
+        </a>{" "}
+        or{" "}
+        <a href="https://outreachdashboard.wmflabs.org" target="_blank" rel="noreferrer">
+          Programs &amp; Events Dashboard
+        </a>{" "}
+        and import the articles they created or edited.
       </p>
+
+      <ToolHowTo
+        steps={[
+          "Enter the editor's username or their Dashboard profile URL.",
+          "Choose which dashboard to search (dashboard.wikiedu.org or outreachdashboard.wmflabs.org).",
+          "Click Run Query.",
+        ]}
+        example={{
+          inputs: [
+            { label: "Username", value: "Ragesoss" },
+            { label: "Dashboard", value: "dashboard.wikiedu.org" },
+          ],
+          result: "the articles Ragesoss created or edited.",
+        }}
+      />
 
       <form onSubmit={handleSubmit}>
         <h3>Enter Username or Profile URL</h3>

--- a/app/frontend/components/wikipedia-category-page.component.tsx
+++ b/app/frontend/components/wikipedia-category-page.component.tsx
@@ -70,10 +70,10 @@ export default function WikipediaCategoryPage() {
     <div className="Container Container--padded">
       <form onSubmit={(e) => handleSubmit(e)}>
         <h1>Impact Search</h1>
-        <p>
-          This tool allows users to browse a wikipedia category and all of its
-          subcategories. Whenever a category is expanded for the first time, the
-          tool will retrieve the data for the subcategories 2 levels down.
+        <p className="ToolIntro">
+          Browse a Wikipedia category and all of its subcategories to collect
+          articles. When a category is expanded for the first time, the tool
+          loads its subcategories two levels down.
         </p>
         <h3>Legend</h3>
         <div>

--- a/app/frontend/components/wikipedia-category-page.component.tsx
+++ b/app/frontend/components/wikipedia-category-page.component.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import toast from "react-hot-toast";
 import { BsExclamationCircleFill } from "react-icons/bs";
 import { CheckBoxIcon } from "./tree-icons.component";
+import ToolHowTo from "./tool-how-to.component";
 
 export default function WikipediaCategoryPage() {
   const [categoryText, setCategoryText] = useState<string>("");
@@ -71,10 +72,28 @@ export default function WikipediaCategoryPage() {
       <form onSubmit={(e) => handleSubmit(e)}>
         <h1>Impact Search</h1>
         <p className="ToolIntro">
-          Browse a Wikipedia category and all of its subcategories to collect
-          articles. When a category is expanded for the first time, the tool
-          loads its subcategories two levels down.
+          Browse a{" "}
+          <a href="https://en.wikipedia.org/wiki/Help:Category" target="_blank" rel="noreferrer">
+            Wikipedia category
+          </a>{" "}
+          and all of its subcategories to collect articles. When a category is
+          expanded for the first time, the tool loads its subcategories two
+          levels down.
         </p>
+        <ToolHowTo
+          steps={[
+            "Enter a two-letter language code (e.g. en).",
+            "Enter a category title or URL (e.g. Category:Women physicists).",
+            "Click Run Query, then expand categories and use the checkboxes to select the subcategories you want.",
+          ]}
+          example={{
+            inputs: [
+              { label: "Language code", value: "en" },
+              { label: "Category", value: "Category:Women physicists" },
+            ],
+            result: "articles from that category and its subcategories.",
+          }}
+        />
         <h3>Legend</h3>
         <div>
           <BsExclamationCircleFill color="#71afef" /> Indicates that the given

--- a/app/frontend/services/topic.service.tsx
+++ b/app/frontend/services/topic.service.tsx
@@ -155,6 +155,14 @@ class TopicService {
       });
   }
 
+  removeArticle(id: number | string, title: string) {
+    return http
+      .delete<Topic>(`/topics/${id}/remove_article`, { params: { title } })
+      .then((response: AxiosResponse) => {
+        return _.get(response, "data");
+      });
+  }
+
   getArticleLanguageComparison(
     id: number | string,
     article: string,

--- a/app/frontend/styles/main.postcss
+++ b/app/frontend/styles/main.postcss
@@ -40,6 +40,7 @@
 @import 'modules/query-builder.postcss';
 @import 'modules/category-tree.postcss';
 @import 'modules/navbar.postcss';
+@import 'modules/search-tool.postcss';
 @import 'modules/forms.postcss';
 @import 'modules/spinner.postcss';
 @import 'modules/autocomplete-input.postcss';

--- a/app/frontend/styles/modules/buttons.postcss
+++ b/app/frontend/styles/modules/buttons.postcss
@@ -111,6 +111,24 @@
   }
 }
 
+.Button--feedback {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background-color: #2e9e5b;
+  border-color: #2e9e5b;
+
+  &:hover {
+    background-color: #268a4f;
+    border-color: #268a4f;
+  }
+}
+
+.Button-icon {
+  width: 16px;
+  height: 16px;
+}
+
 .Button--outlined {
   background: none;
   color: $blue;

--- a/app/frontend/styles/modules/header.postcss
+++ b/app/frontend/styles/modules/header.postcss
@@ -49,3 +49,10 @@
 .Header-adminLabel {
   color: #c62828;
 }
+
+.Header-divider {
+  width: 1px;
+  height: 24px;
+  background: $borderGrey;
+  margin: 0 16px;
+}

--- a/app/frontend/styles/modules/navbar.postcss
+++ b/app/frontend/styles/modules/navbar.postcss
@@ -7,7 +7,7 @@
     position: absolute;
     background-color: #f9f9f9;
     background-image: linear-gradient(to bottom right, #ffffff, #f2f2f2);
-    min-width: 200px;
+    min-width: 320px;
     box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
     z-index: 1;
     border-radius: 8px;
@@ -27,6 +27,20 @@
     &:hover {
       background-color: #e8e8e8;
     }
+  }
+
+  .Dropdown-toolName {
+    display: block;
+    font-weight: 600;
+    color: #333333;
+  }
+
+  .Dropdown-toolDesc {
+    display: block;
+    margin-top: 3px;
+    font-size: 12px;
+    color: #666666;
+    line-height: 1.3;
   }
 
   &:hover {

--- a/app/frontend/styles/modules/search-tool.postcss
+++ b/app/frontend/styles/modules/search-tool.postcss
@@ -4,3 +4,52 @@
   color: #555555;
   line-height: 1.4;
 }
+
+.ToolIntro a {
+  text-decoration: underline;
+}
+
+.ToolHowTo {
+  max-width: 640px;
+  margin-bottom: 20px;
+  color: #555555;
+}
+
+.ToolHowTo summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #333333;
+  margin-bottom: 8px;
+}
+
+.ToolHowTo ol {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.ToolHowTo li {
+  margin-bottom: 4px;
+}
+
+.ToolHowTo-example {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background-color: #f5f5f5;
+  border-left: 3px solid #cccccc;
+}
+
+.ToolHowTo-exampleInputs {
+  list-style: none;
+  margin: 6px 0;
+  padding: 0;
+}
+
+.ToolHowTo-exampleInputs li {
+  margin-bottom: 2px;
+}
+
+.ToolHowTo-example code {
+  padding: 1px 5px;
+  background-color: #e6e6e6;
+  font-family: monospace;
+}

--- a/app/frontend/styles/modules/search-tool.postcss
+++ b/app/frontend/styles/modules/search-tool.postcss
@@ -1,0 +1,6 @@
+.ToolIntro {
+  max-width: 640px;
+  margin-bottom: 20px;
+  color: #555555;
+  line-height: 1.4;
+}

--- a/app/frontend/styles/modules/topic-detail.postcss
+++ b/app/frontend/styles/modules/topic-detail.postcss
@@ -66,6 +66,12 @@
   flex: 1;
 }
 
+.TopicProgress-updatedAt {
+  color: $blue;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
 .TopicProgress-eta {
   font-size: 0.75rem;
   color: $mediumGrey;

--- a/app/frontend/styles/modules/topic-detail.postcss
+++ b/app/frontend/styles/modules/topic-detail.postcss
@@ -5,6 +5,8 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
 }
 
 .TopicDetailIntro {
@@ -13,6 +15,18 @@
   justify-content: space-between;
   border-bottom: 1px solid $borderGrey;
   padding-bottom: 2rem;
+}
+
+.TopicDetailIntro-main {
+  background: white;
+  border-radius: 4px;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.1);
+  padding: 20px 24px;
+  align-self: flex-start;
+}
+
+.TopicDetailIntro-description :last-child {
+  margin-bottom: 0;
 }
 
 .TopicDetail-noStats {
@@ -216,12 +230,6 @@
 
 .TopicProgress-startButton {
   align-self: flex-start;
-}
-
-.TopicProgress-editLink {
-  font-size: 0.85rem;
-  color: $mediumGrey;
-  text-decoration: underline;
 }
 
 .TopicProgress-finePrint {

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -855,6 +855,33 @@ $danger-fg: #c62828;
       }
     }
 
+    .RemoveBtn {
+      margin-left: auto;
+      margin-right: 8px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: none;
+      border: 1px solid $danger-fg;
+      color: $danger-fg;
+      cursor: pointer;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 13px;
+      transition:
+        background-color 120ms ease,
+        color 120ms ease;
+
+      &:hover {
+        background-color: $danger-bg;
+      }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    }
+
     .Close {
       background: none;
       border: none;
@@ -1370,6 +1397,33 @@ $danger-fg: #c62828;
 
   .TrimBtn + .Link {
     padding-left: 8px;
+  }
+
+  .Item .RemoveBtn {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    padding: 8px 12px 8px 4px;
+    background: none;
+    border: none;
+    color: #c2c2c2;
+    cursor: pointer;
+    opacity: 0;
+    transition:
+      opacity 100ms ease,
+      color 120ms ease;
+
+    &:hover {
+      color: $danger-fg;
+    }
+
+    &:disabled {
+      cursor: default;
+    }
+  }
+
+  .Item:hover .RemoveBtn {
+    opacity: 1;
   }
 
   .Item.is-excluded .Link {

--- a/app/frontend/styles/modules/wiki-bubble-chart.postcss
+++ b/app/frontend/styles/modules/wiki-bubble-chart.postcss
@@ -1044,6 +1044,11 @@ $danger-fg: #c62828;
     flex-direction: column;
     overflow: hidden;
 
+    .ColBody {
+      display: flex;
+      flex-direction: column;
+    }
+
     .SectionHeader {
       font-size: 14px;
       font-weight: 600;
@@ -1099,6 +1104,19 @@ $danger-fg: #c62828;
       color: #4a4a4a;
       font-style: italic;
       padding: 16px 20px;
+    }
+
+    .Credit {
+      margin-top: auto;
+      font-size: 12px;
+      color: #4a4a4a;
+      padding: 12px 20px;
+      border-top: 1px solid rgba(0, 0, 0, 0.1);
+
+      a {
+        color: #2e7d32;
+        text-decoration: underline;
+      }
     }
   }
 }

--- a/app/frontend/types/bubble-chart.type.tsx
+++ b/app/frontend/types/bubble-chart.type.tsx
@@ -45,6 +45,10 @@ type BubbleSizeFields = {
   prev_article_size?: number | null;
   lead_section_size?: number;
   talk_size?: number;
+  assessment_grade_color?: string;
+  talk_color?: string;
+  prev_article_color?: string;
+  lead_color?: string;
 };
 
 type RadiusScale = (v: number | null | undefined) => number;

--- a/app/frontend/types/topic.type.tsx
+++ b/app/frontend/types/topic.type.tsx
@@ -28,6 +28,7 @@ export default interface Topic {
   token_count_delta: number;
   has_stats: boolean;
   has_analytics: boolean;
+  data_updated_at: string | null;
   owned: boolean;
   users_csv_url: string;
   users_csv_filename: string;

--- a/app/frontend/utils/article-quality-utils.ts
+++ b/app/frontend/utils/article-quality-utils.ts
@@ -1,6 +1,10 @@
 // Threshold and feature mapping ported from the Wikimedia microtask-generator:
 // https://gitlab.wikimedia.org/toolforge-repos/microtask-generator/-/blob/main/main.py
 
+export const MICROTASK_GENERATOR_NAME = "microtask-generator";
+export const MICROTASK_GENERATOR_URL =
+  "https://gitlab.wikimedia.org/toolforge-repos/microtask-generator";
+
 export const QUALITY_THRESHOLD = 0.5;
 
 export const QUALITY_CHECKS: { key: string; message: string }[] = [

--- a/app/frontend/utils/bubble-chart-utils.tsx
+++ b/app/frontend/utils/bubble-chart-utils.tsx
@@ -243,30 +243,53 @@ function makeSqrtAreaScale(
   };
 }
 
+function shadeColor(hex: string, amount: number): string {
+  const num = parseInt(hex.replace("#", ""), 16);
+  const channel = (shift: number) => {
+    const c = (num >> shift) & 0xff;
+    const next = amount < 0 ? c * (1 + amount) : c + (255 - c) * amount;
+    return Math.min(255, Math.max(0, Math.round(next)));
+  };
+  const r = channel(16);
+  const g = channel(8);
+  const b = channel(0);
+  return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
+}
+
+const RAW_ASSESSMENT_COLORS: Record<string, string> = {
+  FA: "#9CBDFF",
+  GA: "#66FF66",
+  A: "#66FFFF",
+  FL: "#9CBDFF",
+  B: "#B2FF66",
+  C: "#FFFF66",
+  Start: "#FFAA66",
+  Stub: "#FFA4A4",
+  List: "#C7B1FF",
+};
+const UNASSESSED_COLOR = "#9e9e9e";
+const BASE_DARKEN = -0.12;
+
 function getAssessmentColor(grade?: string | null): string {
-  if (!grade) return "#9e9e9e";
-  switch (grade) {
-    case "FA":
-      return "#9CBDFF";
-    case "GA":
-      return "#66FF66";
-    case "A":
-      return "#66FFFF";
-    case "FL":
-      return "#9CBDFF";
-    case "B":
-      return "#B2FF66";
-    case "C":
-      return "#FFFF66";
-    case "Start":
-      return "#FFAA66";
-    case "Stub":
-      return "#FFA4A4";
-    case "List":
-      return "#C7B1FF";
-    default:
-      return "#9e9e9e";
-  }
+  const raw = (grade && RAW_ASSESSMENT_COLORS[grade]) || UNASSESSED_COLOR;
+  return shadeColor(raw, BASE_DARKEN);
+}
+
+type AssessmentPalette = {
+  article: string;
+  lead: string;
+  talk: string;
+  prevArticle: string;
+};
+
+function getAssessmentPalette(grade?: string | null): AssessmentPalette {
+  const base = getAssessmentColor(grade);
+  return {
+    article: base,
+    lead: shadeColor(base, 0.35),
+    talk: shadeColor(base, -0.22),
+    prevArticle: shadeColor(base, -0.1),
+  };
 }
 
 export {
@@ -277,5 +300,9 @@ export {
   convertAnalyticsToCSV,
   convertAnalyticsToWikitext,
   getAssessmentColor,
+  getAssessmentPalette,
+  shadeColor,
   makeSqrtAreaScale,
 };
+
+export type { AssessmentPalette };

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -218,6 +218,35 @@ class Topic < ApplicationRecord
     topic_article_analytics.maximum(:updated_at)
   end
 
+  # Remove a single article (by title) from the active bag, hard-deleting its
+  # topic-scoped analytics + timepoints. Mirrors the batch cleanup in
+  # TopicBuilderSyncService#apply_removes!. The Article + ArticleTimepoint rows
+  # are article-scoped (possibly shared with other topics) and are left intact.
+  # Returns true if an article was removed, false if the title isn't in the bag.
+  def remove_article_from_active_bag!(title:)
+    bag = active_article_bag
+    return false unless bag
+
+    article_bag_article = bag.article_bag_articles.joins(:article).find_by(articles: { title: })
+    return false unless article_bag_article
+
+    article_id = article_bag_article.article_id
+
+    transaction do
+      TopicArticleTimepoint
+        .joins(:topic_timepoint, :article_timepoint)
+        .where(topic_timepoints: { topic_id: id },
+               article_timepoints: { article_id: })
+        .delete_all
+
+      TopicArticleAnalytic.where(topic_id: id, article_id:).delete_all
+
+      ArticleBagArticle.where(id: article_bag_article.id).delete_all
+    end
+
+    true
+  end
+
   def queue_articles_import
     job_id = ImportArticlesJob.perform_async(id)
     update article_import_job_id: job_id

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -214,6 +214,10 @@ class Topic < ApplicationRecord
     topic_article_analytics.with_pageviews.exists? && topic_article_analytics.with_size.exists?
   end
 
+  def data_updated_at
+    topic_article_analytics.maximum(:updated_at)
+  end
+
   def queue_articles_import
     job_id = ImportArticlesJob.perform_async(id)
     update article_import_job_id: job_id

--- a/app/views/topics/_topic.jbuilder
+++ b/app/views/topics/_topic.jbuilder
@@ -27,6 +27,7 @@ end
 
 json.has_stats topic.most_recent_summary.present?
 json.has_analytics topic.article_analytics_exist?
+json.data_updated_at topic.data_updated_at
 json.owned owned
 
 # Data-generation status — exposed to everyone so non-owners can see

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       get :generate_article_analytics, on: :member
       get :incremental_topic_build, on: :member
       post :start_data_generation, on: :member
+      delete :remove_article, on: :member
       get :topic_article_analytics, on: :member
       get :language_links, on: :member
       get :article_language_comparison, on: :member


### PR DESCRIPTION
## Changes

**New features**
- Added the ability to remove articles from a topic directly from the chart
  - Owners get a "Remove from topic" button in the article detail panel and a trash icon on each row of the filtered-articles sidebar
  - Removal hard-deletes the article's topic-scoped analytics and timepoints (mirroring the Topic Builder sync cleanup) through a new owner-gated `DELETE /topics/:id/remove_article` endpoint
  - The chart bubbles and aggregate stat cells refresh automatically after a removal, and a confirm dialog warns when a Topic Builder sync could later re-add the article
- Added a "Last updated" date to the topic data panel
- Added "How to use" explanations for each topic-building tool
  - PagePile, PetScan, Query Builder, User Set, and Wiki Dashboard tools now share a how-to component describing how to use them
- Added tags to the glossary and clearer descriptions for each tool
- Added bubble colors based on assessment grade
- Added proper crediting for the microtask generator in the article detail panel's contribution suggestions
- Moved the create topic button and added a feedback button
- Moved the edit topic button and updated the topic-description styling

**Videos/Screenshots**

Improved tool instructions and feedback button demo

https://github.com/user-attachments/assets/2eaa93e7-1c8a-4095-9403-0fd029fd012e

Chart new features demo

https://github.com/user-attachments/assets/cd45619a-d129-4c70-86fa-138f979cd784



