### PR TITLE
Chart axis/filtering bug fixes + new single-color option

### DIFF
--- a/app/frontend/components/bubble-cell.component.tsx
+++ b/app/frontend/components/bubble-cell.component.tsx
@@ -53,24 +53,24 @@ const BubbleCell: React.FC<BubbleCellProps> = ({
         <circle
           r={scales.talk(row.talk_size)}
           fill="none"
-          stroke={row.talk_color ?? "#2196f3"}
+          stroke={row.bubble_talk_color ?? "#2196f3"}
           strokeWidth={1.5}
         />
         <circle
           r={scales.prevArticle(row.prev_article_size)}
           fill="none"
-          stroke={row.prev_article_color ?? "#64b5f6"}
+          stroke={row.bubble_prev_color ?? "#64b5f6"}
           strokeWidth={1.5}
           strokeDasharray="4 4"
         />
         <circle
           r={scales.lead(row.lead_section_size)}
-          fill={row.lead_color ?? "#90caf9"}
+          fill={row.bubble_lead_color ?? "#90caf9"}
           opacity={0.8}
         />
         <circle
           r={scales.article(row.article_size)}
-          fill={row.assessment_grade_color ?? "#0d47a1"}
+          fill={row.bubble_article_color ?? "#0d47a1"}
           opacity={0.5}
           stroke="white"
           strokeWidth={1}

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -99,11 +99,13 @@ const patchChartScales = (vgSpec: any) => {
         scales.push(base);
         vgSpec.scales = scales;
       }
-      const B = "domain('x_base')";
+      // convert to number to avoid issues with date objects
+      const Blo = "toNumber(domain('x_base')[0])";
+      const Bhi = "toNumber(domain('x_base')[1])";
       const clamp = (proposed: string) =>
-        `(span(${proposed}) >= span(${B}) ? ${B}` +
-        ` : (${proposed})[0] < ${B}[0] ? [${B}[0], ${B}[0] + span(${proposed})]` +
-        ` : (${proposed})[1] > ${B}[1] ? [${B}[1] - span(${proposed}), ${B}[1]]` +
+        `(span(${proposed}) >= (${Bhi} - ${Blo}) ? [${Blo}, ${Bhi}]` +
+        ` : (${proposed})[0] < ${Blo} ? [${Blo}, ${Blo} + span(${proposed})]` +
+        ` : (${proposed})[1] > ${Bhi} ? [${Bhi} - span(${proposed}), ${Bhi}]` +
         ` : (${proposed}))`;
       for (const sig of vgSpec.signals || []) {
         if (!Array.isArray(sig.on)) continue;

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -401,6 +401,35 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     return { min, max };
   }, [rows, yAxisConfig.currentField, excludedOutliers]);
 
+  // Full-data extent for the x axis, used to pin the x scale domain so filtering
+  // hides bubbles without repacking or re-scaling (articles keep a fixed x
+  // position). Computed over all rows for the current x field.
+  const xFullDomain = useMemo<[number, number] | null>(() => {
+    const isScaled = xAxisMode === "scaled" && xAxisKey !== "title";
+    if (!isScaled) {
+      return rows.length ? [1, rows.length] : null;
+    }
+    let min = Infinity;
+    let max = -Infinity;
+    let found = false;
+    for (let i = 0; i < rows.length; i++) {
+      const v =
+        xAxisKey === "publication_date"
+          ? rows[i].publication_date
+            ? Date.parse(rows[i].publication_date as string)
+            : NaN
+          : (rows[i] as any)[xAxisKey];
+      if (typeof v === "number" && Number.isFinite(v)) {
+        if (v < min) min = v;
+        if (v > max) max = v;
+        found = true;
+      }
+    }
+    return found ? [min, max] : null;
+  }, [rows, xAxisKey, xAxisMode]);
+  const xDomainMin = xFullDomain ? xFullDomain[0] : null;
+  const xDomainMax = xFullDomain ? xFullDomain[1] : null;
+
   const parsedYAxisDomain = useMemo(() => {
     const parsedMin =
       committedYAxisMinInput.trim() === ""
@@ -637,10 +666,13 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         };
 
     // Edge padding so the first/last bubble isn't clipped (the pan clamp
-    // otherwise pins the domain flush to the data).
+    // otherwise pins the domain flush to the data). Pin the domain to the full
+    // data extent so filtering hides bubbles without repacking/re-scaling —
+    // every article keeps a fixed x position for comparison across filters.
     xEncoding.scale = {
       ...(xEncoding.scale || {}),
       padding: MAX_CIRCLE_RADIUS,
+      ...(xFullDomain ? { domain: xFullDomain } : {}),
     };
 
     const yFieldExpr = `datum[${JSON.stringify(yAxisConfig.currentField)}]`;
@@ -718,9 +750,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       background: "#ffffff",
       data: { name: "main", values: currentSortedRows },
       transform: [
+        { window: [{ op: "row_number", as: "idx" }], sort: rankedSort },
         { filter: yFilterExpr },
         { filter: visibilityFilterExpr },
-        { window: [{ op: "row_number", as: "idx" }], sort: rankedSort },
       ],
       config: {
         legend: { disable: true },
@@ -1055,6 +1087,8 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
     yAxisScaleType,
     yAxisAutoDomain.min,
     yAxisAutoDomain.max,
+    xDomainMin,
+    xDomainMax,
     excludedKey,
     availableTagsKey,
   ]);

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -676,6 +676,21 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       tagFilterExpr,
     ].join(" && ");
 
+    const rankedSortField =
+      xAxisKey === "title"
+        ? "article"
+        : xAxisKey === "publication_date"
+          ? "publication_date"
+          : xAxisKey;
+
+    const rankedSort =
+      rankedSortField === "article"
+        ? [{ field: "article", order: "ascending" as const }]
+        : [
+            { field: rankedSortField, order: "ascending" as const },
+            { field: "article", order: "ascending" as const },
+          ];
+
     const isLargeDataset = currentSortedRows.length > LARGE_DATASET_THRESHOLD;
 
     const useHighlight = !isLargeDataset;
@@ -703,7 +718,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       transform: [
         { filter: yFilterExpr },
         { filter: visibilityFilterExpr },
-        { window: [{ op: "row_number", as: "idx" }] },
+        { window: [{ op: "row_number", as: "idx" }], sort: rankedSort },
       ],
       config: {
         legend: { disable: true },

--- a/app/frontend/components/wiki-bubble-chart.component.tsx
+++ b/app/frontend/components/wiki-bubble-chart.component.tsx
@@ -40,6 +40,7 @@ import {
   convertAnalyticsToCSV,
   convertAnalyticsToWikitext,
   getAssessmentPalette,
+  SINGLE_COLOR_PALETTE,
   compareArticlesByPublicationDateAsc,
   compareArticlesByNumericFieldAsc,
   formatProtectionSummary,
@@ -252,6 +253,9 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
   const [showLabels, setShowLabels] = useState<boolean>(
     initialState.showLabels,
   );
+  const [colorMode, setColorMode] = useState<"assessment" | "single">(
+    initialState.colorMode,
+  );
   const [excludedOutliers, setExcludedOutliers] = useState<Set<string>>(
     () => new Set(initialState.excludedOutliers),
   );
@@ -296,15 +300,17 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
         const hasMoveRestriction = protections.some((p) => p.type === "move");
         const hasEditRestriction = protections.some((p) => p.type === "edit");
         const palette = getAssessmentPalette(analytics?.assessment_grade);
+        const bubble = colorMode === "single" ? SINGLE_COLOR_PALETTE : palette;
 
         return {
           article,
           ...analytics,
           classifications: analytics?.classifications ?? [],
           assessment_grade_color: palette.article,
-          talk_color: palette.talk,
-          prev_article_color: palette.prevArticle,
-          lead_color: palette.lead,
+          bubble_article_color: bubble.article,
+          bubble_talk_color: bubble.talk,
+          bubble_prev_color: bubble.prevArticle,
+          bubble_lead_color: bubble.lead,
           protection_summary: formatProtectionSummary(protections),
           has_move_restriction: hasMoveRestriction,
           has_edit_restriction: hasEditRestriction,
@@ -312,7 +318,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       });
     }
     return [];
-  }, [data]);
+  }, [data, colorMode]);
 
   const availableTags = useMemo(() => {
     const set = new Set<string>();
@@ -885,7 +891,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               scale: { type: "sqrt", range: [50, 1500] },
             },
             stroke: {
-              field: "talk_color",
+              field: "bubble_talk_color",
               type: "nominal",
               scale: null,
               legend: null,
@@ -910,7 +916,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               scale: { type: "sqrt", range: [20, 600] },
             },
             stroke: {
-              field: "prev_article_color",
+              field: "bubble_prev_color",
               type: "nominal",
               scale: null,
               legend: null,
@@ -933,7 +939,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               scale: { type: "sqrt", range: [30, 800] },
             },
             fill: {
-              field: "lead_color",
+              field: "bubble_lead_color",
               type: "nominal",
               scale: null,
               legend: null,
@@ -992,7 +998,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
               scale: { type: "sqrt", range: [20, 600] },
             },
             fill: {
-              field: "assessment_grade_color",
+              field: "bubble_article_color",
               type: "nominal",
               scale: null,
               legend: null,
@@ -1385,6 +1391,7 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
       includeNoCentrality,
       searchTerm,
       showLabels,
+      colorMode,
       selectedGrades,
       deselectedTags: [...deselectedTags],
       includeUntagged,
@@ -1554,6 +1561,19 @@ export const WikiBubbleChart: React.FC<WikiBubbleChartProps> = ({
                 onChange={(e) => handleShowLabelsChange(e.target.checked)}
               />
               <span>Show labels</span>
+            </label>
+            <label
+              className="ShowLabels"
+              title="Color every bubble the same instead of by quality assessment. Useful for accessibility and for wikis without assessment grades."
+            >
+              <input
+                type="checkbox"
+                checked={colorMode === "single"}
+                onChange={(e) =>
+                  setColorMode(e.target.checked ? "single" : "assessment")
+                }
+              />
+              <span>Single color</span>
             </label>
             <ArticleSearchAutocomplete
               searchTerm={searchTerm}

--- a/app/frontend/types/bubble-chart.type.tsx
+++ b/app/frontend/types/bubble-chart.type.tsx
@@ -33,7 +33,10 @@ type NumericSortField =
   | "images_count";
 
 type XAxisKey = "title" | "publication_date" | NumericSortField;
-type YAxisKey = "average_daily_views" | "number_of_editors" | "incoming_links_count";
+type YAxisKey =
+  | "average_daily_views"
+  | "number_of_editors"
+  | "incoming_links_count";
 
 type NumericSortableArticle = { article: string } & Record<
   NumericSortField,
@@ -46,9 +49,10 @@ type BubbleSizeFields = {
   lead_section_size?: number;
   talk_size?: number;
   assessment_grade_color?: string;
-  talk_color?: string;
-  prev_article_color?: string;
-  lead_color?: string;
+  bubble_article_color?: string;
+  bubble_talk_color?: string;
+  bubble_prev_color?: string;
+  bubble_lead_color?: string;
 };
 
 type RadiusScale = (v: number | null | undefined) => number;

--- a/app/frontend/utils/bubble-chart-permalink.ts
+++ b/app/frontend/utils/bubble-chart-permalink.ts
@@ -14,6 +14,7 @@ export interface ChartUiState {
   includeNoCentrality: boolean;
   searchTerm: string;
   showLabels: boolean;
+  colorMode: "assessment" | "single";
   selectedGrades: Record<string, boolean>;
   deselectedTags: string[];
   includeUntagged: boolean;
@@ -66,6 +67,7 @@ export const DEFAULT_CHART_UI_STATE: ChartUiState = {
   includeNoCentrality: true,
   searchTerm: "",
   showLabels: false,
+  colorMode: "assessment",
   selectedGrades: Object.fromEntries(GRADE_KEYS.map((g) => [g, true])),
   deselectedTags: [],
   includeUntagged: true,
@@ -94,6 +96,7 @@ export function encodeChartState(state: ChartUiState): Record<string, string> {
   if (!state.includeNoCentrality) params.cna = "0";
   if (state.searchTerm.trim() !== "") params.q = state.searchTerm.trim();
   if (state.showLabels) params.lbl = "1";
+  if (state.colorMode === "single") params.mono = "1";
 
   if (!allGradesOn(state.selectedGrades)) {
     const off = GRADE_KEYS.filter((g) => state.selectedGrades[g] === false);
@@ -170,6 +173,8 @@ export function decodeChartState(params: URLSearchParams): ChartUiState {
   if (q) state.searchTerm = q;
 
   state.showLabels = params.get("lbl") === "1";
+
+  state.colorMode = params.get("mono") === "1" ? "single" : "assessment";
 
   const off = params.get("off");
   if (off) {

--- a/app/frontend/utils/bubble-chart-utils.tsx
+++ b/app/frontend/utils/bubble-chart-utils.tsx
@@ -282,8 +282,7 @@ type AssessmentPalette = {
   prevArticle: string;
 };
 
-function getAssessmentPalette(grade?: string | null): AssessmentPalette {
-  const base = getAssessmentColor(grade);
+function getPaletteFromBase(base: string): AssessmentPalette {
   return {
     article: base,
     lead: shadeColor(base, 0.35),
@@ -292,7 +291,16 @@ function getAssessmentPalette(grade?: string | null): AssessmentPalette {
   };
 }
 
+function getAssessmentPalette(grade?: string | null): AssessmentPalette {
+  return getPaletteFromBase(getAssessmentColor(grade));
+}
+
+const SINGLE_COLOR_BASE = "#2f6d9e";
+const SINGLE_COLOR_PALETTE: AssessmentPalette =
+  getPaletteFromBase(SINGLE_COLOR_BASE);
+
 export {
+  SINGLE_COLOR_PALETTE,
   compareArticlesByPublicationDateAsc,
   compareArticlesByNumericFieldAsc,
   formatProtectionSummary,


### PR DESCRIPTION
## Changes

**Bug fixes**
- Fixed a bug where A–Z sorting would fail when re-rendering
  - Toggling a color/filter off then on made those bubbles pile up on the right instead of returning to their alphabetical spot; ranked-mode order is now assigned with an explicit sort
- Fixed an issue where bubbles would clamp to the left when panning a date axis
  - The pan/zoom clamp now coerces the scale bounds to numbers, so panning to the edge on a temporal (creation date) axis no longer produces an invalid domain that collapsed the bubbles
- Made the chart stop adjusting for filtered-out bubbles, keeping their absolute positioning
  - The x-axis domain is pinned to the full data extent and positions are ranked over all articles, so toggling a filter just hides bubbles instead of re-scaling the axis and shifting everything left (Applies to A–Z as well as the scaled modes [size, date, links, etc])

**New features**
- Added a single-color option for the chart
  - A new "Single color" checkbox colors every bubble the same instead of by quality-assessment grade, for accessibility and for wikis without assessment grades (Also applies to the bubbles in the Languages tab, and the choice is saved in the chart permalink)
 
**Videos/Screenshots**

https://github.com/user-attachments/assets/83f5eb28-dbbc-42ef-b650-ed534fbc6525

